### PR TITLE
ci: improve triggers and permissions in workflows

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -1,14 +1,13 @@
 name: Benchmark for PR
 on:
   pull_request_target:
-    branches:
-      - master
     paths:
       - "crates/typstyle-core/**"
+      - ".github/workflows/bench-pr.yml"
   workflow_dispatch:
 
 jobs:
-  pre_build:
+  pre_job:
     permissions:
       actions: write
       contents: read
@@ -20,11 +19,14 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          cancel_others: true
+          cancel_others: "true"
 
   bench:
     name: Run benches
     runs-on: ubuntu-latest
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    timeout-minutes: 30
     permissions:
       pull-requests: write
     steps:
@@ -53,10 +55,10 @@ jobs:
 
       - name: Compare and comment results
         run: |
-          # 生成比较结果
+          # Generate comparison results
           BENCH_RESULT=$(critcmp --color never base pr)
 
-          # 生成评论内容
+          # Generate comment content
           echo "BENCHMARK_COMMENT<<EOF" >> $GITHUB_ENV
           echo "### 📊 Benchmark Performance Report" >> $GITHUB_ENV
           echo "" >> $GITHUB_ENV

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
     paths:
       - "playground/**"
       - "docs/**"

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -6,10 +6,10 @@ on:
     tags:
       - "v*"
   pull_request:
-    types: [opened, synchronize]
-    branches:
-      - master
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
   CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
@@ -53,6 +53,8 @@ jobs:
       - run: cargo check --workspace
 
   test:
+    needs: [pre_build]
+    if: needs.pre_build.outputs.should_skip != 'true'
     name: Run tests
     runs-on: ubuntu-latest
     steps:
@@ -99,6 +101,7 @@ jobs:
 
   build:
     needs: [pre_build]
+    if: needs.pre_build.outputs.should_skip != 'true'
     strategy:
       matrix:
         include:
@@ -214,6 +217,7 @@ jobs:
 
   build_alpine:
     needs: [pre_build]
+    if: needs.pre_build.outputs.should_skip != 'true'
     name: build (x86_64-unknown-linux-musl)
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Todo later: do not run tests when changes do not touch rust lib, but ensure releasing work.

Something like this, but need fine-grained skip check in individual jobs.

```yml
      - id: skip_check
        uses: fkirc/skip-duplicate-actions@v5
        with:
          cancel_others: "true"
          paths: |
            - "Cargo.toml"
            - "Cargo.lock"
            - "crates/**"
            - "tests/**"
            - ".github/workflows/test-and-release.yml"
```