### PR TITLE
fix: update grayespinoza to typstyle-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The playground integrates the latest version of typstyle. If you encounter forma
 
 ### [3rd party] Use as a GitHub Action
 
-The [typstyle-action](https://github.com/grayespinoza/typstyle-action) maintained by [@grayespinoza](https://github.com/grayespinoza) can install and run typstyle in github action.
+The [typstyle-action](https://github.com/typstyle-rs/typstyle-action) maintained by [@grayespinoza](https://github.com/grayespinoza) can install and run typstyle in a GitHub Action.
 
 ## Features & Design
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The playground integrates the latest version of typstyle. If you encounter forma
 - **NPM**: <https://www.npmjs.com/package/typstyle-core>
 - **Rust**: <https://crates.io/crates/typstyle-core>
 
-### [3rd party] Use as a GitHub Action
+ ### Use as a GitHub Action
 
 The [typstyle-action](https://github.com/typstyle-rs/typstyle-action) maintained by [@grayespinoza](https://github.com/grayespinoza) can install and run typstyle in a GitHub Action.
 


### PR DESCRIPTION
Updates `grayespinoza` reference in GitHub Action section of`README.md` to `typstyle-rs`.

As long as I have a personal fork of the GitHub Action, it'll redirect to mine instead of the actual action.