### PR TITLE
fix: properly handle parenthesized args and trailing content blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## Unreleased
+
+- Bug fix: In code mode, `std.table` was not recognized as a table function, preventing proper table formatting.
+
+- Bug fix: Fixed incorrect formatting of table functions with empty content blocks.
+  When `table.header` or `table.footer` had no parentheses (`()`), the formatter would incorrectly add parentheses before empty content blocks. When parenthesized args are empty, the formatter would insert a line break with short line length.
+  For example:
+  ```typst
+  #table(
+    columns: 2,
+    table.header[],
+    table.footer(),
+  )
+  ```
+  was formatted to:
+  ```typst
+  #table(
+    columns: 2,
+    table.header()[],
+    table.footer(),
+  )
+  ```
+  or with short line length:
+  ```typst
+  #table(
+    columns: 2,
+    table.header(
+
+    )[],
+    table.footer(
+
+    ),
+  )
+  ```
+
+- Bug fix: Fixed incorrect handling of trailing content blocks in set rules.
+  Previously, when there were no parentheses, a following content block would be wrapped by `()`; when parentheses were already present, any trailing content block was dropped.
+  For example:
+  ```typst
+  #set circle[1]
+  #set circle()[1]
+  #set circle(stroke: blue)[1]
+  ```
+  was previously formatted to:
+  ```typst
+  #set circle([1])
+  #set circle()
+  #set circle(stroke: blue)
+  ```
+
 ## v0.13.13 - [2025-07-02]
 
 - Bug fix(CI): Fixed a CI misconfiguration that prevented the release of v0.13.12.

--- a/crates/typstyle-core/src/pretty/code_chain.rs
+++ b/crates/typstyle-core/src/pretty/code_chain.rs
@@ -102,7 +102,7 @@ impl<'a> PrettyPrinter<'a> {
                 doc += self.arena.text(".") + self.convert_ident(field_access.field());
             }
         }
-        doc += self.convert_args(ctx, func_call.args());
+        doc += self.convert_args_of_func(ctx, func_call);
         Some(doc)
     }
 
@@ -123,7 +123,7 @@ impl<'a> PrettyPrinter<'a> {
                 |ctx, node| {
                     if let Some(func_call) = node.cast::<FuncCall>() {
                         // There is no comment allowed, so we can directly convert args.
-                        Some(self.convert_args(ctx, func_call.args()))
+                        Some(self.convert_args_of_func(ctx, func_call))
                     } else {
                         node.cast().map(|expr| self.convert_expr(ctx, expr))
                     }

--- a/crates/typstyle-core/src/pretty/code_flow.rs
+++ b/crates/typstyle-core/src/pretty/code_flow.rs
@@ -252,7 +252,9 @@ impl<'a> PrettyPrinter<'a> {
                 FlowItem::spaced(self.convert_expr(ctx, expr))
             } else if let Some(args) = child.cast() {
                 // args
-                FlowItem::tight_spaced(self.convert_parenthesized_args(ctx, args))
+                FlowItem::tight_spaced(self.convert_args(ctx, args, |nodes| {
+                    self.convert_parenthesized_args_normal(ctx, args, nodes)
+                }))
             } else {
                 FlowItem::none()
             }

--- a/crates/typstyle-core/src/pretty/util.rs
+++ b/crates/typstyle-core/src/pretty/util.rs
@@ -29,7 +29,7 @@ pub fn has_comment_children(node: &SyntaxNode) -> bool {
     node.children().any(is_comment_node)
 }
 
-pub(super) fn func_name(node: FuncCall<'_>) -> Option<&str> {
+pub(super) fn func_name(node: FuncCall) -> Option<&str> {
     match node.callee() {
         Expr::Ident(ident) => Some(ident.as_str()),
         Expr::FieldAccess(field_access) => Some(field_access.field().as_str()),

--- a/tests/fixtures/unit/code/set-rule.typ
+++ b/tests/fixtures/unit/code/set-rule.typ
@@ -1,0 +1,10 @@
+
+#set text(red)
+
+#set circle[666]
+#circle()
+#circle[]
+#set circle()
+#circle()
+#set circle(stroke: blue)[777]
+#circle()

--- a/tests/fixtures/unit/code/snap/set-rule.typ-0.snap
+++ b/tests/fixtures/unit/code/snap/set-rule.typ-0.snap
@@ -1,0 +1,19 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/code/set-rule.typ
+---
+// DUMMY
+
+#set text(
+  red,
+)
+
+#set circle[666]
+#circle()
+#circle[]
+#set circle()
+#circle()
+#set circle(
+  stroke: blue,
+)[777]
+#circle()

--- a/tests/fixtures/unit/code/snap/set-rule.typ-120.snap
+++ b/tests/fixtures/unit/code/snap/set-rule.typ-120.snap
@@ -1,0 +1,15 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/code/set-rule.typ
+---
+// DUMMY
+
+#set text(red)
+
+#set circle[666]
+#circle()
+#circle[]
+#set circle()
+#circle()
+#set circle(stroke: blue)[777]
+#circle()

--- a/tests/fixtures/unit/code/snap/set-rule.typ-40.snap
+++ b/tests/fixtures/unit/code/snap/set-rule.typ-40.snap
@@ -1,0 +1,15 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/code/set-rule.typ
+---
+// DUMMY
+
+#set text(red)
+
+#set circle[666]
+#circle()
+#circle[]
+#set circle()
+#circle()
+#set circle(stroke: blue)[777]
+#circle()

--- a/tests/fixtures/unit/code/snap/set-rule.typ-80.snap
+++ b/tests/fixtures/unit/code/snap/set-rule.typ-80.snap
@@ -1,0 +1,15 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/code/set-rule.typ
+---
+// DUMMY
+
+#set text(red)
+
+#set circle[666]
+#circle()
+#circle[]
+#set circle()
+#circle()
+#set circle(stroke: blue)[777]
+#circle()

--- a/tests/fixtures/unit/table/empty.typ
+++ b/tests/fixtures/unit/table/empty.typ
@@ -1,3 +1,6 @@
+// Empty table
+#table()
+
 // Empty table with only columns
 #table(columns:    3)
 
@@ -11,6 +14,9 @@
 #table(columns:      2,table.header(repeat:    true))
 
 // Table with only footer
+#table(
+  columns:   3,table.footer()
+)
 #table(
   columns:   3,table.footer(
 
@@ -33,3 +39,14 @@
   inset:    5pt,stroke:   (thickness:     1pt,
     dash:       "dotted"),
   ..(fill:     rgb(    "eee")))
+
+
+// No parenthesized args
+#table(
+  columns: 2,
+  table.header[],
+)
+#table(
+  columns: 2,
+  table.header[][],
+)

--- a/tests/fixtures/unit/table/recognize.typ
+++ b/tests/fixtures/unit/table/recognize.typ
@@ -1,0 +1,37 @@
+#table(columns: 2, [1], [2], [3], [4])
+
+#grid(columns: 2, [1], [2], [3], [4])
+
+#std.table(columns: 2, [1], [2], [3], [4])
+
+#std.grid(columns: 2, [1], [2], [3], [4])
+
+#std.table(columns: 2, [1], [2], [3], [4])[5][6]
+
+#std.grid(columns: 2, [1], [2], [3], [4])[5][6]
+
+#table(columns: 2, std.table.header([1], [2], [3], [4]), [3], [4])
+
+#grid(columns: 2, [1], [2], std.grid.footer([1], [2], [3], [4])[5][6])
+
+#{
+  table(
+    columns: 2,
+    [1], [2], [3], [4]
+  )
+
+  std.table(
+    columns: 2,
+    [1], [2], [3], [4]
+  )
+
+  grid(
+    columns: 2,
+    [1], [2], [3], [4]
+  )
+
+  std.grid(
+    columns: 2,
+    [1], [2], [3], [4]
+  )
+}

--- a/tests/fixtures/unit/table/snap/empty.typ-0.snap
+++ b/tests/fixtures/unit/table/snap/empty.typ-0.snap
@@ -2,6 +2,9 @@
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/table/empty.typ
 ---
+// Empty table
+#table()
+
 // Empty table with only columns
 #table(columns: 3)
 
@@ -22,6 +25,10 @@ input_file: tests/fixtures/unit/table/empty.typ
 )
 
 // Table with only footer
+#table(
+  columns: 3,
+  table.footer(),
+)
 #table(
   columns: 3,
   table.footer(
@@ -67,4 +74,15 @@ input_file: tests/fixtures/unit/table/empty.typ
       "eee",
     ),
   )
+)
+
+
+// No parenthesized args
+#table(
+  columns: 2,
+  table.header[],
+)
+#table(
+  columns: 2,
+  table.header[][],
 )

--- a/tests/fixtures/unit/table/snap/empty.typ-120.snap
+++ b/tests/fixtures/unit/table/snap/empty.typ-120.snap
@@ -2,6 +2,9 @@
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/table/empty.typ
 ---
+// Empty table
+#table()
+
 // Empty table with only columns
 #table(columns: 3)
 
@@ -18,6 +21,10 @@ input_file: tests/fixtures/unit/table/empty.typ
 )
 
 // Table with only footer
+#table(
+  columns: 3,
+  table.footer(),
+)
 #table(
   columns: 3,
   table.footer(),
@@ -46,4 +53,15 @@ input_file: tests/fixtures/unit/table/empty.typ
     dash: "dotted",
   ),
   ..(fill: rgb("eee"))
+)
+
+
+// No parenthesized args
+#table(
+  columns: 2,
+  table.header[],
+)
+#table(
+  columns: 2,
+  table.header[][],
 )

--- a/tests/fixtures/unit/table/snap/empty.typ-40.snap
+++ b/tests/fixtures/unit/table/snap/empty.typ-40.snap
@@ -2,6 +2,9 @@
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/table/empty.typ
 ---
+// Empty table
+#table()
+
 // Empty table with only columns
 #table(columns: 3)
 
@@ -18,6 +21,10 @@ input_file: tests/fixtures/unit/table/empty.typ
 )
 
 // Table with only footer
+#table(
+  columns: 3,
+  table.footer(),
+)
 #table(
   columns: 3,
   table.footer(),
@@ -46,4 +53,15 @@ input_file: tests/fixtures/unit/table/empty.typ
     dash: "dotted",
   ),
   ..(fill: rgb("eee"))
+)
+
+
+// No parenthesized args
+#table(
+  columns: 2,
+  table.header[],
+)
+#table(
+  columns: 2,
+  table.header[][],
 )

--- a/tests/fixtures/unit/table/snap/empty.typ-80.snap
+++ b/tests/fixtures/unit/table/snap/empty.typ-80.snap
@@ -2,6 +2,9 @@
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/table/empty.typ
 ---
+// Empty table
+#table()
+
 // Empty table with only columns
 #table(columns: 3)
 
@@ -18,6 +21,10 @@ input_file: tests/fixtures/unit/table/empty.typ
 )
 
 // Table with only footer
+#table(
+  columns: 3,
+  table.footer(),
+)
 #table(
   columns: 3,
   table.footer(),
@@ -46,4 +53,15 @@ input_file: tests/fixtures/unit/table/empty.typ
     dash: "dotted",
   ),
   ..(fill: rgb("eee"))
+)
+
+
+// No parenthesized args
+#table(
+  columns: 2,
+  table.header[],
+)
+#table(
+  columns: 2,
+  table.header[][],
 )

--- a/tests/fixtures/unit/table/snap/recognize.typ-0.snap
+++ b/tests/fixtures/unit/table/snap/recognize.typ-0.snap
@@ -1,0 +1,126 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/table/recognize.typ
+---
+#table(
+  columns: 2,
+  [1],
+  [2],
+
+  [3],
+  [4],
+)
+
+#grid(
+  columns: 2,
+  [1],
+  [2],
+
+  [3],
+  [4],
+)
+
+#std.table(
+  columns: 2,
+  [1],
+  [2],
+
+  [3],
+  [4],
+)
+
+#std.grid(
+  columns: 2,
+  [1],
+  [2],
+
+  [3],
+  [4],
+)
+
+#std.table(
+  columns: 2,
+  [1],
+  [2],
+
+  [3],
+  [4],
+)[5][6]
+
+#std.grid(
+  columns: 2,
+  [1],
+  [2],
+
+  [3],
+  [4],
+)[5][6]
+
+#table(
+  columns: 2,
+  std
+    .table
+    .header(
+    [1],
+    [2],
+
+    [3],
+    [4],
+  ),
+  [3],
+  [4],
+)
+
+#grid(
+  columns: 2,
+  [1],
+  [2],
+
+  std
+    .grid
+    .footer(
+    [1],
+    [2],
+
+    [3],
+    [4],
+  )[5][6],
+)
+
+#{
+  table(
+    columns: 2,
+    [1],
+    [2],
+
+    [3],
+    [4],
+  )
+
+  std.table(
+    columns: 2,
+    [1],
+    [2],
+
+    [3],
+    [4],
+  )
+
+  grid(
+    columns: 2,
+    [1],
+    [2],
+
+    [3],
+    [4],
+  )
+
+  std.grid(
+    columns: 2,
+    [1],
+    [2],
+
+    [3],
+    [4],
+  )
+}

--- a/tests/fixtures/unit/table/snap/recognize.typ-120.snap
+++ b/tests/fixtures/unit/table/snap/recognize.typ-120.snap
@@ -1,0 +1,83 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/table/recognize.typ
+---
+#table(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)
+
+#grid(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)
+
+#std.table(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)
+
+#std.grid(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)
+
+#std.table(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)[5][6]
+
+#std.grid(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)[5][6]
+
+#table(
+  columns: 2,
+  std.table.header(
+    [1], [2],
+    [3], [4],
+  ),
+  [3], [4],
+)
+
+#grid(
+  columns: 2,
+  [1], [2],
+  std.grid.footer(
+    [1], [2],
+    [3], [4],
+  )[5][6],
+)
+
+#{
+  table(
+    columns: 2,
+    [1], [2],
+    [3], [4],
+  )
+
+  std.table(
+    columns: 2,
+    [1], [2],
+    [3], [4],
+  )
+
+  grid(
+    columns: 2,
+    [1], [2],
+    [3], [4],
+  )
+
+  std.grid(
+    columns: 2,
+    [1], [2],
+    [3], [4],
+  )
+}

--- a/tests/fixtures/unit/table/snap/recognize.typ-40.snap
+++ b/tests/fixtures/unit/table/snap/recognize.typ-40.snap
@@ -1,0 +1,83 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/table/recognize.typ
+---
+#table(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)
+
+#grid(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)
+
+#std.table(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)
+
+#std.grid(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)
+
+#std.table(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)[5][6]
+
+#std.grid(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)[5][6]
+
+#table(
+  columns: 2,
+  std.table.header(
+    [1], [2],
+    [3], [4],
+  ),
+  [3], [4],
+)
+
+#grid(
+  columns: 2,
+  [1], [2],
+  std.grid.footer(
+    [1], [2],
+    [3], [4],
+  )[5][6],
+)
+
+#{
+  table(
+    columns: 2,
+    [1], [2],
+    [3], [4],
+  )
+
+  std.table(
+    columns: 2,
+    [1], [2],
+    [3], [4],
+  )
+
+  grid(
+    columns: 2,
+    [1], [2],
+    [3], [4],
+  )
+
+  std.grid(
+    columns: 2,
+    [1], [2],
+    [3], [4],
+  )
+}

--- a/tests/fixtures/unit/table/snap/recognize.typ-80.snap
+++ b/tests/fixtures/unit/table/snap/recognize.typ-80.snap
@@ -1,0 +1,83 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/table/recognize.typ
+---
+#table(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)
+
+#grid(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)
+
+#std.table(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)
+
+#std.grid(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)
+
+#std.table(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)[5][6]
+
+#std.grid(
+  columns: 2,
+  [1], [2],
+  [3], [4],
+)[5][6]
+
+#table(
+  columns: 2,
+  std.table.header(
+    [1], [2],
+    [3], [4],
+  ),
+  [3], [4],
+)
+
+#grid(
+  columns: 2,
+  [1], [2],
+  std.grid.footer(
+    [1], [2],
+    [3], [4],
+  )[5][6],
+)
+
+#{
+  table(
+    columns: 2,
+    [1], [2],
+    [3], [4],
+  )
+
+  std.table(
+    columns: 2,
+    [1], [2],
+    [3], [4],
+  )
+
+  grid(
+    columns: 2,
+    [1], [2],
+    [3], [4],
+  )
+
+  std.grid(
+    columns: 2,
+    [1], [2],
+    [3], [4],
+  )
+}


### PR DESCRIPTION
- Bug fix: In code mode, `std.table` was not recognized as a table function, preventing proper table formatting.

- Bug fix: Fixed incorrect formatting of table functions with empty content blocks.
  When `table.header` or `table.footer` had no no parentheses (`()`), the formatter would incorrectly add parentheses before empty content blocks. When parenthesized args are empty, the formatter would insert an line break with short line length. closes #349 
  For example:
  ```typst
  #table(
    columns: 2,
    table.header[],
    table.footer(),
  )
  ```
  was formatted to:
  ```typst
  #table(
    columns: 2,
    table.header()[],
    table.footer(),
  )
  ```
  or with short line length:
  ```typst
  #table(
    columns: 2,
    table.header(

    )[],
    table.footer(

    ),
  )
  ```

- Bug fix: Fixed incorrect handling of trailing content blocks in set rules.
  Previously, when there were no parentheses, a following content block would be wrapped by `()`; when parentheses were already present, any trailing content block was dropped.
  For example:
  ```typst
  #set circle[1]
  #set circle()[1]
  #set circle(stroke: blue)[1]
  ```
  was previously formatted to:
  ```typst
  #set circle([1])
  #set circle()
  #set circle(stroke: blue)
  ```
