### PR TITLE
feat: treat line comments as line suffixes

### DIFF
--- a/crates/typstyle-core/src/pretty/comment.rs
+++ b/crates/typstyle-core/src/pretty/comment.rs
@@ -13,10 +13,10 @@ enum CommentStyle {
     Bullet,
 }
 
-/// Convert either line comment or block comment.
+/// Convert either line comment or block comment. Line comments are converted as line suffixes.
 pub fn comment<'a>(arena: &'a Arena<'a>, node: &'a SyntaxNode) -> ArenaDoc<'a> {
     if node.kind() == SyntaxKind::LineComment {
-        line_comment(arena, node)
+        line_comment(arena, node).as_line_suffix()
     } else if node.kind() == SyntaxKind::BlockComment {
         block_comment(arena, node)
     } else {

--- a/tests/fixtures/packages/snap/fletcher-diagram.typ-80.snap
+++ b/tests/fixtures/packages/snap/fletcher-diagram.typ-80.snap
@@ -223,9 +223,7 @@ input_file: tests/fixtures/packages/fletcher-diagram.typ
       } else if child.value.class == "edge" {
         let edge = child.value
         edge.vertices.at(0) = map-auto(edge.vertices.at(0), (x, y))
-        if edge.label != none {
-          edge.label = $edge.label$
-        } // why is this needed?
+        if edge.label != none { edge.label = $edge.label$ } // why is this needed?
         edge.vertices.at(-1) = map-auto(edge.vertices.at(-1), (rel: (1, 0)))
         edge.node-index = none
         edges.push(edge)
@@ -264,9 +262,7 @@ input_file: tests/fixtures/packages/fletcher-diagram.typ
     error("Unexpected named argument(s) #..0.", args.named().keys())
   }
 
-  let positional-args = (
-    args.pos().flatten().join() + []
-  ) // join to ensure sequence
+  let positional-args = args.pos().flatten().join() + [] // join to ensure sequence
   let objects = positional-args.children
 
   let nodes = ()

--- a/tests/fixtures/packages/snap/fletcher-draw.typ-40.snap
+++ b/tests/fixtures/packages/snap/fletcher-draw.typ-40.snap
@@ -73,9 +73,7 @@ input_file: tests/fixtures/packages/fletcher-draw.typ
     )
   }
 
-  (node.post)(
-    result,
-  ) // post-process (e.g., hide)
+  (node.post)(result) // post-process (e.g., hide)
 
   // Draw debug stuff
   if debug >= 1 {
@@ -507,8 +505,7 @@ input_file: tests/fixtures/packages/fletcher-draw.typ
         arc-radius: 0 * radius,
         start: θs.at(i - 1) - 90deg,
         delta: wrap-angle-180(Δθ),
-        line-shift: 0
-          * radius, // distance from vertex to beginning of arc
+        line-shift: 0 * radius, // distance from vertex to beginning of arc
       )
     } else {
       // distance from vertex to center of curvature
@@ -525,9 +522,7 @@ input_file: tests/fixtures/packages/fletcher-draw.typ
         start: θs.at(i - 1) - 90deg,
         delta: wrap-angle-180(Δθ),
         line-shift: radius
-          * calc.tan(
-            Δθ / 2,
-          ), // distance from vertex to beginning of arc
+          * calc.tan(Δθ / 2), // distance from vertex to beginning of arc
       )
     }
   }
@@ -930,9 +925,7 @@ input_file: tests/fixtures/packages/fletcher-draw.typ
           ),
         debug: debug,
       )
-      (edge.post)(
-        obj,
-      ) // post-process (e.g., hide)
+      (edge.post)(obj) // post-process (e.g., hide)
     },
   )
 }
@@ -987,9 +980,7 @@ input_file: tests/fixtures/packages/fletcher-draw.typ
           + (final-vertices: anchors),
         debug: debug,
       )
-      (edge.post)(
-        obj,
-      ) // post-process (e.g., hide)
+      (edge.post)(obj) // post-process (e.g., hide)
     },
   )
 }
@@ -1011,15 +1002,8 @@ input_file: tests/fixtures/packages/fletcher-draw.typ
   )
 
   let end-segments = (
-    edge
-      .final-vertices
-      .slice(
-        0,
-        2,
-      ), // first two vertices
-    edge
-      .final-vertices
-      .slice(-2), // last two vertices
+    edge.final-vertices.slice(0, 2), // first two vertices
+    edge.final-vertices.slice(-2), // last two vertices
   )
 
   let dummy-lines = end-segments.map(
@@ -1059,9 +1043,7 @@ input_file: tests/fixtures/packages/fletcher-draw.typ
         edge,
         debug: debug,
       )
-      (edge.post)(
-        obj,
-      ) // post-process (e.g., hide)
+      (edge.post)(obj) // post-process (e.g., hide)
     },
   )
 }

--- a/tests/fixtures/packages/snap/fletcher-draw.typ-80.snap
+++ b/tests/fixtures/packages/snap/fletcher-draw.typ-80.snap
@@ -344,9 +344,7 @@ input_file: tests/fixtures/packages/fletcher-draw.typ
     let dir = if Δθ > 0deg { +1 } else { -1 } // +1 if ccw, -1 if cw
 
 
-    let θ-normal = (
-      θs.at(i - 1) + Δθ / 2 + 90deg
-    ) // direction to center of curvature
+    let θ-normal = θs.at(i - 1) + Δθ / 2 + 90deg // direction to center of curvature
 
     let radius = edge.corner-radius
     // radius *= 90deg/calc.max(calc.abs(Δθ), 45deg) // visual adjustment so that tighter bends have smaller radii
@@ -377,8 +375,7 @@ input_file: tests/fixtures/packages/fletcher-draw.typ
         arc-radius: radius,
         start: θs.at(i - 1) - 90deg,
         delta: wrap-angle-180(Δθ),
-        line-shift: radius
-          * calc.tan(Δθ / 2), // distance from vertex to beginning of arc
+        line-shift: radius * calc.tan(Δθ / 2), // distance from vertex to beginning of arc
       )
     }
   }

--- a/tests/fixtures/packages/snap/tablex.typ-120.snap
+++ b/tests/fixtures/packages/snap/tablex.typ-120.snap
@@ -1085,12 +1085,7 @@ input_file: tests/fixtures/packages/tablex.typ
       } else {
         let index = grid-index-at(px, py)
 
-        grid.items.at(index) = occupied(
-          x: px,
-          y: py,
-          parent_x: this_x,
-          parent_y: this_y,
-        ) // indicate this position's parent cell (to join them later)
+        grid.items.at(index) = occupied(x: px, y: py, parent_x: this_x, parent_y: this_y) // indicate this position's parent cell (to join them later)
       }
     }
 
@@ -2625,10 +2620,7 @@ input_file: tests/fixtures/packages/tablex.typ
 
     current_row += 1
     row_group_add_counter = calc.max(0, row_group_add_counter - 1) // one row added
-    header_rows_count = calc.max(
-      0,
-      header_rows_count - 1,
-    ) // ensure at least the amount of requested header rows was added
+    header_rows_count = calc.max(0, header_rows_count - 1) // ensure at least the amount of requested header rows was added
 
     // added all pertaining rows to the group
     // now we can draw it

--- a/tests/fixtures/packages/snap/tablex.typ-40.snap
+++ b/tests/fixtures/packages/snap/tablex.typ-40.snap
@@ -752,9 +752,7 @@ input_file: tests/fixtures/packages/tablex.typ
     return 0pt // page has 'auto' size => % should return 0
   }
 
-  (
-    ((len / 1%) / 100) * page-size + 0pt
-  ) // e.g. 100% / 1% = 100; / 100 = 1; 1 * page-size
+  ((len / 1%) / 100) * page-size + 0pt // e.g. 100% / 1% = 100; / 100 = 1; 1 * page-size
 }
 
 // Convert a fraction type length to pt
@@ -1377,9 +1375,7 @@ input_file: tests/fixtures/packages/tablex.typ
           "Invalid line received (must be hline or vline).",
         )
       }
-      items.at(
-        i,
-      ) = item // override item with the new x / y coord set
+      items.at(i) = item // override item with the new x / y coord set
       continue
     }
 
@@ -1679,10 +1675,7 @@ input_file: tests/fixtures/packages/tablex.typ
     type(align_default)
       == _function-type
   ) {
-    align_default(
-      cell.x,
-      cell.y,
-    ) // column, row
+    align_default(cell.x, cell.y) // column, row
   } else {
     align_default
   }
@@ -1690,10 +1683,7 @@ input_file: tests/fixtures/packages/tablex.typ
   let fill_default = if (
     type(fill_default) == _function-type
   ) {
-    fill_default(
-      cell.x,
-      cell.y,
-    ) // row, column
+    fill_default(cell.x, cell.y) // row, column
   } else {
     fill_default
   }
@@ -2800,14 +2790,9 @@ input_file: tests/fixtures/packages/tablex.typ
       )
 
       let hline_hasnt_already_ended = (
-        h.end
-          in (
-            auto,
-            none,
-          ) // always goes towards the right
+        h.end in (auto, none) // always goes towards the right
           or h.end
-            >= cell.x
-              + cell.colspan // ends at or after this cell
+            >= cell.x + cell.colspan // ends at or after this cell
       )
 
       (
@@ -2851,14 +2836,9 @@ input_file: tests/fixtures/packages/tablex.typ
       )
 
       let vline_hasnt_already_ended = (
-        v.end
-          in (
-            auto,
-            none,
-          ) // always goes towards the bottom
+        v.end in (auto, none) // always goes towards the bottom
           or v.end
-            >= cell.y
-              + cell.rowspan // ends at or after this cell
+            >= cell.y + cell.rowspan // ends at or after this cell
       )
 
       (
@@ -3498,9 +3478,7 @@ input_file: tests/fixtures/packages/tablex.typ
       page - table-loc.page() + 1
     )
 
-    let at_top = (
-      pos.y == min-pos.y
-    ) // to guard against re-draw issues
+    let at_top = pos.y == min-pos.y // to guard against re-draw issues
     let header_pages = header-pages-state.at(
       loc,
     )
@@ -4914,9 +4892,7 @@ input_file: tests/fixtures/packages/tablex.typ
         grid_info.new_row_count
           - row_len,
       ) {
-        rows.push(
-          last-row-size,
-        ) // add new rows (due to extra cells)
+        rows.push(last-row-size) // add new rows (due to extra cells)
       }
 
       let col_len = columns.len()

--- a/tests/fixtures/packages/snap/tablex.typ-80.snap
+++ b/tests/fixtures/packages/snap/tablex.typ-80.snap
@@ -566,9 +566,7 @@ input_file: tests/fixtures/packages/tablex.typ
     return 0pt // page has 'auto' size => % should return 0
   }
 
-  (
-    ((len / 1%) / 100) * page-size + 0pt
-  ) // e.g. 100% / 1% = 100; / 100 = 1; 1 * page-size
+  ((len / 1%) / 100) * page-size + 0pt // e.g. 100% / 1% = 100; / 100 = 1; 1 * page-size
 }
 
 // Convert a fraction type length to pt
@@ -1457,10 +1455,7 @@ input_file: tests/fixtures/packages/tablex.typ
           )
         }
 
-        let pcell = get-parent-cell(
-          cell,
-          grid: grid,
-        ) // in case this is a colspan
+        let pcell = get-parent-cell(cell, grid: grid) // in case this is a colspan
         let last-auto-col = get-colspan-last-auto-col(pcell, columns: columns)
 
         let fit-this-span = if (
@@ -1522,10 +1517,7 @@ input_file: tests/fixtures/packages/tablex.typ
             align_default: auto,
           )
 
-          let width = measure(
-            cell-box,
-            styles,
-          ).width // + 2*cell_inset // the box already considers inset
+          let width = measure(cell-box, styles).width // + 2*cell_inset // the box already considers inset
 
           // here, we are excluding from the width of this cell
           // at this column all width that was already covered by
@@ -1749,10 +1741,7 @@ input_file: tests/fixtures/packages/tablex.typ
           )
         }
 
-        let pcell = get-parent-cell(
-          cell,
-          grid: grid,
-        ) // in case this is a rowspan
+        let pcell = get-parent-cell(cell, grid: grid) // in case this is a rowspan
         let last-auto-row = get-rowspan-last-auto-row(pcell, rows: rows)
 
         let fit-this-span = if (
@@ -1787,10 +1776,7 @@ input_file: tests/fixtures/packages/tablex.typ
           // measure the cell's actual height,
           // with its calculated width
           // and with other constraints
-          let height = measure(
-            cell-box,
-            styles,
-          ).height // + 2*cell_inset (box already considers inset)
+          let height = measure(cell-box, styles).height // + 2*cell_inset (box already considers inset)
 
           // here, we are excluding from the height of this cell
           // at this row all height that was already covered by
@@ -2225,18 +2211,12 @@ input_file: tests/fixtures/packages/tablex.typ
 
   if start == parent-start {
     // starts where its parent starts
-    expansion.at(0) = default-if-auto(
-      line.expand.at(0),
-      0pt,
-    ) // => expand to the left
+    expansion.at(0) = default-if-auto(line.expand.at(0), 0pt) // => expand to the left
   }
 
   if end == parent-end {
     // ends where its parent ends
-    expansion.at(1) = default-if-auto(
-      line.expand.at(1),
-      0pt,
-    ) // => expand to the right
+    expansion.at(1) = default-if-auto(line.expand.at(1), 0pt) // => expand to the right
   }
 
   expansion
@@ -2288,9 +2268,7 @@ input_file: tests/fixtures/packages/tablex.typ
       stroke-auto: stroke-auto,
       styles: styles,
     )
-    left-expand += (
-      largest-stroke(default-if-auto-or-none(start, 0)) / 2
-    ) // expand to the left to close stroke gap
+    left-expand += largest-stroke(default-if-auto-or-none(start, 0)) / 2 // expand to the left to close stroke gap
     right-expand += (
       largest-stroke(default-if-auto-or-none(end, columns.len())) / 2
     ) // close stroke gap to the right
@@ -2399,9 +2377,7 @@ input_file: tests/fixtures/packages/tablex.typ
       stroke-auto: stroke-auto,
       styles: styles,
     )
-    top-expand += (
-      largest-stroke(default-if-auto-or-none(start, 0)) / 2
-    ) // close stroke gap to the top
+    top-expand += largest-stroke(default-if-auto-or-none(start, 0)) / 2 // close stroke gap to the top
     bottom-expand += (
       largest-stroke(default-if-auto-or-none(end, rows.len())) / 2
     ) // close stroke gap to the bottom
@@ -2933,14 +2909,8 @@ input_file: tests/fixtures/packages/tablex.typ
     }
 
     current_row += 1
-    row_group_add_counter = calc.max(
-      0,
-      row_group_add_counter - 1,
-    ) // one row added
-    header_rows_count = calc.max(
-      0,
-      header_rows_count - 1,
-    ) // ensure at least the amount of requested header rows was added
+    row_group_add_counter = calc.max(0, row_group_add_counter - 1) // one row added
+    header_rows_count = calc.max(0, header_rows_count - 1) // ensure at least the amount of requested header rows was added
 
     // added all pertaining rows to the group
     // now we can draw it
@@ -2985,10 +2955,7 @@ input_file: tests/fixtures/packages/tablex.typ
 
       if is_header {
         // this is now the header group.
-        first_row_group = (
-          row_group: row-group,
-          content: content,
-        ) // 'content' to repeat later
+        first_row_group = (row_group: row-group, content: content) // 'content' to repeat later
       }
 
       (content,)

--- a/tests/fixtures/unit/markup/reflow/snap/commented.typ-40.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/commented.typ-40.snap
@@ -4,8 +4,7 @@ input_file: tests/fixtures/unit/markup/reflow/commented.typ
 ---
 /// typstyle: wrap_text
 
-This is a paragraph with
-// an inline comment that shouldn't break
+This is a paragraph with // an inline comment that shouldn't break
 the flow of text or create a new line.
 The formatter should handle
 // multiple comments spread across
@@ -17,8 +16,7 @@ Here's text with
 *strong text* and $"math" "equations"$
 to ensure /* multi-line
           block comments */ don't
-interfere with text flow or
-// inline elements.
+interfere with text flow or // inline elements.
 
 Testing comments near special
 characters: a + b // comment after plus
@@ -30,5 +28,4 @@ A complex case mixing everything: *bold
 text* // comment after strong
 `code block` /* block comment */ with
 $"math"$ // final comment
-and #text(red)[colored text]
-// with formatting
+and #text(red)[colored text] // with formatting


### PR DESCRIPTION
WIP: wait for upstream feature stablized

Now line comments no longer take up any space.

Question: should it also apply to trailing block comments?