### PR TITLE
fix: use portable relative URL for git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/packages/hypraw"]
 	path = docs/packages/hypraw
-	url = git@github.com:QuadnucYard/typst-hypraw.git
+	url = ../../QuadnucYard/typst-hypraw.git


### PR DESCRIPTION
Change submodule URL from absolute SSH format to relative path format (../../QuadnucYard/typst-hypraw.git) to make it protocol-agnostic.

This allows users to clone the repository without requiring a GitHub account, as the relative URL will resolve correctly regardless of whether HTTPS or SSH is used for the initial clone.

Fixes #347