### PR TITLE
docs: add CLAUDE.md for Claude Code guidance

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,39 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-code-action:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run rust cache
+        uses: Swatinem/rust-cache@v2
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          timeout_minutes: "60"
+          claude_env: |
+            ANTHROPIC_BASE_URL=${{ secrets.ANTHROPIC_BASE_URL }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**typstyle** is a beautiful and reliable code formatter for [Typst](https://typst.app/). It's built in Rust and uses Wadler's pretty printing algorithm to consistently format Typst source code.
+
+## Architecture
+
+The project is organized as a Cargo workspace with these main crates:
+
+- **`typstyle-core`**: Core formatting logic with Wadler's pretty printer
+- **`typstyle`**: CLI application built on top of core
+- **`typstyle-wasm`**: WebAssembly bindings for web usage
+- **`typstyle-typlugin`**: Typst plugin (WASM target)
+- **`typstyle-consistency`**: Testing utilities for convergence tests
+
+## Development Commands
+
+### Build & Test
+```bash
+cargo build                    # Build all crates
+cargo test                     # Run all tests
+cargo test -p typstyle-core    # Run specific crate tests
+cargo test --test unit         # Run unit tests only
+cargo test --test e2e          # Run end-to-end tests
+```
+
+### CLI Usage
+```bash
+cargo run -p typstyle -- --help              # Show CLI help
+cargo run -p typstyle -- -i file.typ         # Format file in place
+cargo run -p typstyle -- --check file.typ    # Check formatting
+cargo run -p typstyle -- --diff file.typ     # Show diff
+```
+
+### Documentation & Development
+```bash
+just dev-docs           # Serve documentation locally
+just build-docs         # Build documentation
+just build-plugin       # Build typst plugin WASM
+just generate-cli-help  # Update CLI help text
+```
+
+### Testing
+The project uses comprehensive testing:
+- **Snapshot tests**: Use `insta` crate, outputs in `tests/fixtures/*/snap/`
+- **Convergence tests**: Ensure formatting converges (format twice = same result)
+- **Correctness tests**: Ensure rendered output unchanged after formatting
+- **E2E tests**: Test against real repos like `tablex`, `cetz`, `fletcher`
+
+### Benchmarking
+```bash
+cargo bench -p typstyle-core    # Run benchmarks
+cargo bench --bench pretty_print # Pretty printing benchmarks
+```
+
+## Key Files
+
+- **Entry points**: `crates/typstyle/src/main.rs` (CLI), `crates/typstyle-core/src/lib.rs` (core)
+- **Formatting logic**: `crates/typstyle-core/src/pretty/` contains formatting rules
+- **Configuration**: `crates/typstyle-core/src/config.rs`
+- **Tests**: `tests/` directory with unit, e2e, and fixtures
+
+## Formatting Features
+
+- **Opinionated**: Consistent style across codebases
+- **Code-only**: Formats code, preserves content formatting
+- **Convergence**: Running formatter twice produces same result
+- **Correctness**: Preserves rendered output appearance
+
+## Development Notes
+
+- Requires Rust 1.83+
+- Uses `just` for task automation
+- Web playground available at `/playground/` directory
+- Documentation uses shiroa for static site generation


### PR DESCRIPTION
Add CLAUDE.md file to provide guidance for Claude Code instances working with this repository.

https://docs.anthropic.com/en/docs/claude-code/github-actions

Contains:
- Project architecture overview (workspace structure)
- Essential development commands for build, test, and documentation
- Key directories and files for quick navigation
- Testing and benchmark instructions

This helps future Claude Code instances quickly understand the codebase structure and development workflow.