### PR TITLE
feat(web): persist playground state in url

### DIFF
--- a/playground/.prettierrc
+++ b/playground/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false,
+  "useTabs": false
+}

--- a/playground/package.json
+++ b/playground/package.json
@@ -32,6 +32,8 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "lz-string": "^1.5.0",
+    "query-string": "^9.2.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "typstyle-wasm": "file:typstyle-wasm",

--- a/playground/pnpm-lock.yaml
+++ b/playground/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      lz-string:
+        specifier: ^1.5.0
+        version: 1.5.0
+      query-string:
+        specifier: ^9.2.2
+        version: 9.2.2
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -158,203 +164,199 @@ packages:
     hasBin: true
 
   '@biomejs/cli-darwin-arm64@2.0.0':
-    resolution: {integrity: sha512-QvqWYtFFhhxdf8jMAdJzXW+Frc7X8XsnHQLY+TBM1fnT1TfeV/v9vsFI5L2J7GH6qN1+QEEJ19jHibCY2Ypplw==, tarball: https://registry.npmmirror.com/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.0.tgz}
+    resolution: {integrity: sha512-QvqWYtFFhhxdf8jMAdJzXW+Frc7X8XsnHQLY+TBM1fnT1TfeV/v9vsFI5L2J7GH6qN1+QEEJ19jHibCY2Ypplw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
   '@biomejs/cli-darwin-x64@2.0.0':
-    resolution: {integrity: sha512-5JFhls1EfmuIH4QGFPlNpxJQFC6ic3X1ltcoLN+eSRRIPr6H/lUS1ttuD0Fj7rPgPhZqopK/jfH8UVj/1hIsQw==, tarball: https://registry.npmmirror.com/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.0.tgz}
+    resolution: {integrity: sha512-5JFhls1EfmuIH4QGFPlNpxJQFC6ic3X1ltcoLN+eSRRIPr6H/lUS1ttuD0Fj7rPgPhZqopK/jfH8UVj/1hIsQw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
   '@biomejs/cli-linux-arm64-musl@2.0.0':
-    resolution: {integrity: sha512-Bxsz8ki8+b3PytMnS5SgrGV+mbAWwIxI3ydChb/d1rURlJTMdxTTq5LTebUnlsUWAX6OvJuFeiVq9Gjn1YbCyA==, tarball: https://registry.npmmirror.com/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.0.tgz}
+    resolution: {integrity: sha512-Bxsz8ki8+b3PytMnS5SgrGV+mbAWwIxI3ydChb/d1rURlJTMdxTTq5LTebUnlsUWAX6OvJuFeiVq9Gjn1YbCyA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.0.0':
-    resolution: {integrity: sha512-BAH4QVi06TzAbVchXdJPsL0Z/P87jOfes15rI+p3EX9/EGTfIjaQ9lBVlHunxcmoptaA5y1Hdb9UYojIhmnjIw==, tarball: https://registry.npmmirror.com/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.0.tgz}
+    resolution: {integrity: sha512-BAH4QVi06TzAbVchXdJPsL0Z/P87jOfes15rI+p3EX9/EGTfIjaQ9lBVlHunxcmoptaA5y1Hdb9UYojIhmnjIw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.0.0':
-    resolution: {integrity: sha512-tiQ0ABxMJb9I6GlfNp0ulrTiQSFacJRJO8245FFwE3ty3bfsfxlU/miblzDIi+qNrgGsLq5wIZcVYGp4c+HXZA==, tarball: https://registry.npmmirror.com/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.0.tgz}
+    resolution: {integrity: sha512-tiQ0ABxMJb9I6GlfNp0ulrTiQSFacJRJO8245FFwE3ty3bfsfxlU/miblzDIi+qNrgGsLq5wIZcVYGp4c+HXZA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.0.0':
-    resolution: {integrity: sha512-09PcOGYTtkopWRm6mZ/B6Mr6UHdkniUgIG/jLBv+2J8Z61ezRE+xQmpi3yNgUrFIAU4lPA9atg7mhvE/5Bo7Wg==, tarball: https://registry.npmmirror.com/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.0.tgz}
+    resolution: {integrity: sha512-09PcOGYTtkopWRm6mZ/B6Mr6UHdkniUgIG/jLBv+2J8Z61ezRE+xQmpi3yNgUrFIAU4lPA9atg7mhvE/5Bo7Wg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.0.0':
-    resolution: {integrity: sha512-vrTtuGu91xNTEQ5ZcMJBZuDlqr32DWU1r14UfePIGndF//s2WUAmer4FmgoPgruo76rprk37e8S2A2c0psXdxw==, tarball: https://registry.npmmirror.com/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.0.tgz}
+    resolution: {integrity: sha512-vrTtuGu91xNTEQ5ZcMJBZuDlqr32DWU1r14UfePIGndF//s2WUAmer4FmgoPgruo76rprk37e8S2A2c0psXdxw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
   '@biomejs/cli-win32-x64@2.0.0':
-    resolution: {integrity: sha512-2USVQ0hklNsph/KIR72ZdeptyXNnQ3JdzPn3NbjI4Sna34CnxeiYAaZcZzXPDl5PYNFBivV4xmvT3Z3rTmyDBg==, tarball: https://registry.npmmirror.com/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.0.tgz}
+    resolution: {integrity: sha512-2USVQ0hklNsph/KIR72ZdeptyXNnQ3JdzPn3NbjI4Sna34CnxeiYAaZcZzXPDl5PYNFBivV4xmvT3Z3rTmyDBg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
 
   '@esbuild/aix-ppc64@0.25.5':
-    resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==, tarball: https://registry.npmmirror.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz}
+    resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.25.5':
-    resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==, tarball: https://registry.npmmirror.com/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz}
+    resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm@0.25.5':
-    resolution: {integrity: sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==, tarball: https://registry.npmmirror.com/@esbuild/android-arm/-/android-arm-0.25.5.tgz}
+    resolution: {integrity: sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
   '@esbuild/android-x64@0.25.5':
-    resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==, tarball: https://registry.npmmirror.com/@esbuild/android-x64/-/android-x64-0.25.5.tgz}
+    resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.25.5':
-    resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==, tarball: https://registry.npmmirror.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz}
+    resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.5':
-    resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==, tarball: https://registry.npmmirror.com/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz}
+    resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.25.5':
-    resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==, tarball: https://registry.npmmirror.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz}
+    resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.5':
-    resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==, tarball: https://registry.npmmirror.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz}
+    resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.25.5':
-    resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==, tarball: https://registry.npmmirror.com/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz}
+    resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.5':
-    resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==, tarball: https://registry.npmmirror.com/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz}
+    resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.25.5':
-    resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==, tarball: https://registry.npmmirror.com/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz}
+    resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.5':
-    resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==, tarball: https://registry.npmmirror.com/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz}
+    resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.25.5':
-    resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==, tarball: https://registry.npmmirror.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz}
+    resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.5':
-    resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==, tarball: https://registry.npmmirror.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz}
+    resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-riscv64@0.25.5':
-    resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==, tarball: https://registry.npmmirror.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz}
+    resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.5':
-    resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==, tarball: https://registry.npmmirror.com/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz}
+    resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.5':
-    resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==, tarball: https://registry.npmmirror.com/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz}
+    resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-arm64@0.25.5':
-    resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==, tarball: https://registry.npmmirror.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz}
+    resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.5':
-    resolution: {integrity: sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==, tarball: https://registry.npmmirror.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz}
+    resolution: {integrity: sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.25.5':
-    resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==, tarball: https://registry.npmmirror.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz}
+    resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.5':
-    resolution: {integrity: sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==, tarball: https://registry.npmmirror.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz}
+    resolution: {integrity: sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/sunos-x64@0.25.5':
-    resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==, tarball: https://registry.npmmirror.com/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz}
+    resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.25.5':
-    resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==, tarball: https://registry.npmmirror.com/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz}
+    resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.25.5':
-    resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==, tarball: https://registry.npmmirror.com/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz}
+    resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.5':
-    resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==, tarball: https://registry.npmmirror.com/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz}
+    resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -404,176 +406,161 @@ packages:
         optional: true
 
   '@rollup/rollup-android-arm-eabi@4.44.0':
-    resolution: {integrity: sha512-xEiEE5oDW6tK4jXCAyliuntGR+amEMO7HLtdSshVuhFnKTYoeYMyXQK7pLouAJJj5KHdwdn87bfHAR2nSdNAUA==, tarball: https://registry.npmmirror.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.0.tgz}
+    resolution: {integrity: sha512-xEiEE5oDW6tK4jXCAyliuntGR+amEMO7HLtdSshVuhFnKTYoeYMyXQK7pLouAJJj5KHdwdn87bfHAR2nSdNAUA==}
     cpu: [arm]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.44.0':
-    resolution: {integrity: sha512-uNSk/TgvMbskcHxXYHzqwiyBlJ/lGcv8DaUfcnNwict8ba9GTTNxfn3/FAoFZYgkaXXAdrAA+SLyKplyi349Jw==, tarball: https://registry.npmmirror.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.0.tgz}
+    resolution: {integrity: sha512-uNSk/TgvMbskcHxXYHzqwiyBlJ/lGcv8DaUfcnNwict8ba9GTTNxfn3/FAoFZYgkaXXAdrAA+SLyKplyi349Jw==}
     cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-darwin-arm64@4.44.0':
-    resolution: {integrity: sha512-VGF3wy0Eq1gcEIkSCr8Ke03CWT+Pm2yveKLaDvq51pPpZza3JX/ClxXOCmTYYq3us5MvEuNRTaeyFThCKRQhOA==, tarball: https://registry.npmmirror.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.0.tgz}
+    resolution: {integrity: sha512-VGF3wy0Eq1gcEIkSCr8Ke03CWT+Pm2yveKLaDvq51pPpZza3JX/ClxXOCmTYYq3us5MvEuNRTaeyFThCKRQhOA==}
     cpu: [arm64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.44.0':
-    resolution: {integrity: sha512-fBkyrDhwquRvrTxSGH/qqt3/T0w5Rg0L7ZIDypvBPc1/gzjJle6acCpZ36blwuwcKD/u6oCE/sRWlUAcxLWQbQ==, tarball: https://registry.npmmirror.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.0.tgz}
+    resolution: {integrity: sha512-fBkyrDhwquRvrTxSGH/qqt3/T0w5Rg0L7ZIDypvBPc1/gzjJle6acCpZ36blwuwcKD/u6oCE/sRWlUAcxLWQbQ==}
     cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-freebsd-arm64@4.44.0':
-    resolution: {integrity: sha512-u5AZzdQJYJXByB8giQ+r4VyfZP+walV+xHWdaFx/1VxsOn6eWJhK2Vl2eElvDJFKQBo/hcYIBg/jaKS8ZmKeNQ==, tarball: https://registry.npmmirror.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.0.tgz}
+    resolution: {integrity: sha512-u5AZzdQJYJXByB8giQ+r4VyfZP+walV+xHWdaFx/1VxsOn6eWJhK2Vl2eElvDJFKQBo/hcYIBg/jaKS8ZmKeNQ==}
     cpu: [arm64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.44.0':
-    resolution: {integrity: sha512-qC0kS48c/s3EtdArkimctY7h3nHicQeEUdjJzYVJYR3ct3kWSafmn6jkNCA8InbUdge6PVx6keqjk5lVGJf99g==, tarball: https://registry.npmmirror.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.0.tgz}
+    resolution: {integrity: sha512-qC0kS48c/s3EtdArkimctY7h3nHicQeEUdjJzYVJYR3ct3kWSafmn6jkNCA8InbUdge6PVx6keqjk5lVGJf99g==}
     cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.44.0':
-    resolution: {integrity: sha512-x+e/Z9H0RAWckn4V2OZZl6EmV0L2diuX3QB0uM1r6BvhUIv6xBPL5mrAX2E3e8N8rEHVPwFfz/ETUbV4oW9+lQ==, tarball: https://registry.npmmirror.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.0.tgz}
+    resolution: {integrity: sha512-x+e/Z9H0RAWckn4V2OZZl6EmV0L2diuX3QB0uM1r6BvhUIv6xBPL5mrAX2E3e8N8rEHVPwFfz/ETUbV4oW9+lQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.44.0':
-    resolution: {integrity: sha512-1exwiBFf4PU/8HvI8s80icyCcnAIB86MCBdst51fwFmH5dyeoWVPVgmQPcKrMtBQ0W5pAs7jBCWuRXgEpRzSCg==, tarball: https://registry.npmmirror.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.0.tgz}
+    resolution: {integrity: sha512-1exwiBFf4PU/8HvI8s80icyCcnAIB86MCBdst51fwFmH5dyeoWVPVgmQPcKrMtBQ0W5pAs7jBCWuRXgEpRzSCg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.44.0':
-    resolution: {integrity: sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==, tarball: https://registry.npmmirror.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.0.tgz}
+    resolution: {integrity: sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.44.0':
-    resolution: {integrity: sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==, tarball: https://registry.npmmirror.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.0.tgz}
+    resolution: {integrity: sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.44.0':
-    resolution: {integrity: sha512-xw+FTGcov/ejdusVOqKgMGW3c4+AgqrfvzWEVXcNP6zq2ue+lsYUgJ+5Rtn/OTJf7e2CbgTFvzLW2j0YAtj0Gg==, tarball: https://registry.npmmirror.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.0.tgz}
+    resolution: {integrity: sha512-xw+FTGcov/ejdusVOqKgMGW3c4+AgqrfvzWEVXcNP6zq2ue+lsYUgJ+5Rtn/OTJf7e2CbgTFvzLW2j0YAtj0Gg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.44.0':
-    resolution: {integrity: sha512-bKGibTr9IdF0zr21kMvkZT4K6NV+jjRnBoVMt2uNMG0BYWm3qOVmYnXKzx7UhwrviKnmK46IKMByMgvpdQlyJQ==, tarball: https://registry.npmmirror.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.0.tgz}
+    resolution: {integrity: sha512-bKGibTr9IdF0zr21kMvkZT4K6NV+jjRnBoVMt2uNMG0BYWm3qOVmYnXKzx7UhwrviKnmK46IKMByMgvpdQlyJQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.44.0':
-    resolution: {integrity: sha512-vV3cL48U5kDaKZtXrti12YRa7TyxgKAIDoYdqSIOMOFBXqFj2XbChHAtXquEn2+n78ciFgr4KIqEbydEGPxXgA==, tarball: https://registry.npmmirror.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.0.tgz}
+    resolution: {integrity: sha512-vV3cL48U5kDaKZtXrti12YRa7TyxgKAIDoYdqSIOMOFBXqFj2XbChHAtXquEn2+n78ciFgr4KIqEbydEGPxXgA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.44.0':
-    resolution: {integrity: sha512-TDKO8KlHJuvTEdfw5YYFBjhFts2TR0VpZsnLLSYmB7AaohJhM8ctDSdDnUGq77hUh4m/djRafw+9zQpkOanE2Q==, tarball: https://registry.npmmirror.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.0.tgz}
+    resolution: {integrity: sha512-TDKO8KlHJuvTEdfw5YYFBjhFts2TR0VpZsnLLSYmB7AaohJhM8ctDSdDnUGq77hUh4m/djRafw+9zQpkOanE2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.44.0':
-    resolution: {integrity: sha512-8541GEyktXaw4lvnGp9m84KENcxInhAt6vPWJ9RodsB/iGjHoMB2Pp5MVBCiKIRxrxzJhGCxmNzdu+oDQ7kwRA==, tarball: https://registry.npmmirror.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.0.tgz}
+    resolution: {integrity: sha512-8541GEyktXaw4lvnGp9m84KENcxInhAt6vPWJ9RodsB/iGjHoMB2Pp5MVBCiKIRxrxzJhGCxmNzdu+oDQ7kwRA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.44.0':
-    resolution: {integrity: sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==, tarball: https://registry.npmmirror.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.0.tgz}
+    resolution: {integrity: sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.44.0':
-    resolution: {integrity: sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==, tarball: https://registry.npmmirror.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.0.tgz}
+    resolution: {integrity: sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.44.0':
-    resolution: {integrity: sha512-M0CpcHf8TWn+4oTxJfh7LQuTuaYeXGbk0eageVjQCKzYLsajWS/lFC94qlRqOlyC2KvRT90ZrfXULYmukeIy7w==, tarball: https://registry.npmmirror.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.0.tgz}
+    resolution: {integrity: sha512-M0CpcHf8TWn+4oTxJfh7LQuTuaYeXGbk0eageVjQCKzYLsajWS/lFC94qlRqOlyC2KvRT90ZrfXULYmukeIy7w==}
     cpu: [arm64]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.44.0':
-    resolution: {integrity: sha512-3XJ0NQtMAXTWFW8FqZKcw3gOQwBtVWP/u8TpHP3CRPXD7Pd6s8lLdH3sHWh8vqKCyyiI8xW5ltJScQmBU9j7WA==, tarball: https://registry.npmmirror.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.0.tgz}
+    resolution: {integrity: sha512-3XJ0NQtMAXTWFW8FqZKcw3gOQwBtVWP/u8TpHP3CRPXD7Pd6s8lLdH3sHWh8vqKCyyiI8xW5ltJScQmBU9j7WA==}
     cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.44.0':
-    resolution: {integrity: sha512-Q2Mgwt+D8hd5FIPUuPDsvPR7Bguza6yTkJxspDGkZj7tBRn2y4KSWYuIXpftFSjBra76TbKerCV7rgFPQrn+wQ==, tarball: https://registry.npmmirror.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.0.tgz}
+    resolution: {integrity: sha512-Q2Mgwt+D8hd5FIPUuPDsvPR7Bguza6yTkJxspDGkZj7tBRn2y4KSWYuIXpftFSjBra76TbKerCV7rgFPQrn+wQ==}
     cpu: [x64]
     os: [win32]
 
   '@swc/core-darwin-arm64@1.12.3':
-    resolution: {integrity: sha512-QCV9vQ/s27AMxm8j8MTDL/nDoiEMrANiENRrWnb0Fxvz/O39CajPVShp/W7HlOkzt1GYtUXPdQJpSKylugfrWw==, tarball: https://registry.npmmirror.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.12.3.tgz}
+    resolution: {integrity: sha512-QCV9vQ/s27AMxm8j8MTDL/nDoiEMrANiENRrWnb0Fxvz/O39CajPVShp/W7HlOkzt1GYtUXPdQJpSKylugfrWw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
 
   '@swc/core-darwin-x64@1.12.3':
-    resolution: {integrity: sha512-LylCMfzGhdvl5tyKaTT9ePetHUX7wSsST7hxWiHzS+cUMj7FnhcfdEr6kcNVT7y1RJn3fCvuv7T98ZB+T2q3HA==, tarball: https://registry.npmmirror.com/@swc/core-darwin-x64/-/core-darwin-x64-1.12.3.tgz}
+    resolution: {integrity: sha512-LylCMfzGhdvl5tyKaTT9ePetHUX7wSsST7hxWiHzS+cUMj7FnhcfdEr6kcNVT7y1RJn3fCvuv7T98ZB+T2q3HA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
 
   '@swc/core-linux-arm-gnueabihf@1.12.3':
-    resolution: {integrity: sha512-DQODb7S+q+pwQY41Azcavwb2rb4rGxP70niScRDxB9X68hHOM9D0w9fxzC+Nr3AHcPSmVJUYUIiq5h38O5hVgQ==, tarball: https://registry.npmmirror.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.12.3.tgz}
+    resolution: {integrity: sha512-DQODb7S+q+pwQY41Azcavwb2rb4rGxP70niScRDxB9X68hHOM9D0w9fxzC+Nr3AHcPSmVJUYUIiq5h38O5hVgQ==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
   '@swc/core-linux-arm64-gnu@1.12.3':
-    resolution: {integrity: sha512-nTxtJSq78AjeaQBueYImoFBs5j7qXbgOxtirpyt8jE29NQBd0VFzDzRBhkr6I9jq0hNiChgMkqBN4eUkEQjytg==, tarball: https://registry.npmmirror.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.12.3.tgz}
+    resolution: {integrity: sha512-nTxtJSq78AjeaQBueYImoFBs5j7qXbgOxtirpyt8jE29NQBd0VFzDzRBhkr6I9jq0hNiChgMkqBN4eUkEQjytg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.12.3':
-    resolution: {integrity: sha512-lBGvC5UgPSxqLr/y1NZxQhyRQ7nXy3/Ec1Z47YNXtqtpKiG1EcOGPyS0UZgwiYQkXqq8NBFMHnyHmpKnXTvRDA==, tarball: https://registry.npmmirror.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.12.3.tgz}
+    resolution: {integrity: sha512-lBGvC5UgPSxqLr/y1NZxQhyRQ7nXy3/Ec1Z47YNXtqtpKiG1EcOGPyS0UZgwiYQkXqq8NBFMHnyHmpKnXTvRDA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.12.3':
-    resolution: {integrity: sha512-61wZ8hwxNYzBY9MCWB50v90ICzdIhOuPk1O1qXswz9AXw5O6iQStEBHQ1rozPkfQ/rmhepk0pOf/6LCwssJOwg==, tarball: https://registry.npmmirror.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.12.3.tgz}
+    resolution: {integrity: sha512-61wZ8hwxNYzBY9MCWB50v90ICzdIhOuPk1O1qXswz9AXw5O6iQStEBHQ1rozPkfQ/rmhepk0pOf/6LCwssJOwg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.12.3':
-    resolution: {integrity: sha512-NNeBiTpCgWt80vumTKVoaj6Fa/ZjUcaNQNM7np3PIgB8EbuXfyztboV7vUxpkmD/lUgsk8GlEFYViHvo6VMefQ==, tarball: https://registry.npmmirror.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.12.3.tgz}
+    resolution: {integrity: sha512-NNeBiTpCgWt80vumTKVoaj6Fa/ZjUcaNQNM7np3PIgB8EbuXfyztboV7vUxpkmD/lUgsk8GlEFYViHvo6VMefQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.12.3':
-    resolution: {integrity: sha512-fxraM7exaPb1/W0CoHW45EFNOQUQh0nonBEcNFm2iv095mziBwttyxZyQBoDkQocpkd5NtsZw3xW5FTBPnn+Vw==, tarball: https://registry.npmmirror.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.12.3.tgz}
+    resolution: {integrity: sha512-fxraM7exaPb1/W0CoHW45EFNOQUQh0nonBEcNFm2iv095mziBwttyxZyQBoDkQocpkd5NtsZw3xW5FTBPnn+Vw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
   '@swc/core-win32-ia32-msvc@1.12.3':
-    resolution: {integrity: sha512-FFIhMPXIDjRcewomwbYGPvem7Fj76AsuzbRahnAyp+OzJwrrtxVmra/kyUCfj4kix7vdGByY0WvVfiVCf5b7Mg==, tarball: https://registry.npmmirror.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.12.3.tgz}
+    resolution: {integrity: sha512-FFIhMPXIDjRcewomwbYGPvem7Fj76AsuzbRahnAyp+OzJwrrtxVmra/kyUCfj4kix7vdGByY0WvVfiVCf5b7Mg==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
 
   '@swc/core-win32-x64-msvc@1.12.3':
-    resolution: {integrity: sha512-Sf4iSg+IYT5AzFSDDmii08DfeKcvtkVxIuo+uS8BJMbiLjFNjgMkkVlBthknGyJcSK15ncg9248XjnM4jU8DZA==, tarball: https://registry.npmmirror.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.12.3.tgz}
+    resolution: {integrity: sha512-Sf4iSg+IYT5AzFSDDmii08DfeKcvtkVxIuo+uS8BJMbiLjFNjgMkkVlBthknGyJcSK15ncg9248XjnM4jU8DZA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -597,65 +584,61 @@ packages:
     resolution: {integrity: sha512-2ACf1znY5fpRBwRhMgj9ZXvb2XZW8qs+oTfotJ2C5xR0/WNL7UHZ7zXl6s+rUqedL1mNi+0O+WQr5awGowS3PQ==, tarball: https://registry.npmmirror.com/@tailwindcss/node/-/node-4.1.10.tgz}
 
   '@tailwindcss/oxide-android-arm64@4.1.10':
-    resolution: {integrity: sha512-VGLazCoRQ7rtsCzThaI1UyDu/XRYVyH4/EWiaSX6tFglE+xZB5cvtC5Omt0OQ+FfiIVP98su16jDVHDEIuH4iQ==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.10.tgz}
+    resolution: {integrity: sha512-VGLazCoRQ7rtsCzThaI1UyDu/XRYVyH4/EWiaSX6tFglE+xZB5cvtC5Omt0OQ+FfiIVP98su16jDVHDEIuH4iQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
 
   '@tailwindcss/oxide-darwin-arm64@4.1.10':
-    resolution: {integrity: sha512-ZIFqvR1irX2yNjWJzKCqTCcHZbgkSkSkZKbRM3BPzhDL/18idA8uWCoopYA2CSDdSGFlDAxYdU2yBHwAwx8euQ==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.10.tgz}
+    resolution: {integrity: sha512-ZIFqvR1irX2yNjWJzKCqTCcHZbgkSkSkZKbRM3BPzhDL/18idA8uWCoopYA2CSDdSGFlDAxYdU2yBHwAwx8euQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
   '@tailwindcss/oxide-darwin-x64@4.1.10':
-    resolution: {integrity: sha512-eCA4zbIhWUFDXoamNztmS0MjXHSEJYlvATzWnRiTqJkcUteSjO94PoRHJy1Xbwp9bptjeIxxBHh+zBWFhttbrQ==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.10.tgz}
+    resolution: {integrity: sha512-eCA4zbIhWUFDXoamNztmS0MjXHSEJYlvATzWnRiTqJkcUteSjO94PoRHJy1Xbwp9bptjeIxxBHh+zBWFhttbrQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
   '@tailwindcss/oxide-freebsd-x64@4.1.10':
-    resolution: {integrity: sha512-8/392Xu12R0cc93DpiJvNpJ4wYVSiciUlkiOHOSOQNH3adq9Gi/dtySK7dVQjXIOzlpSHjeCL89RUUI8/GTI6g==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.10.tgz}
+    resolution: {integrity: sha512-8/392Xu12R0cc93DpiJvNpJ4wYVSiciUlkiOHOSOQNH3adq9Gi/dtySK7dVQjXIOzlpSHjeCL89RUUI8/GTI6g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [freebsd]
 
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.10':
-    resolution: {integrity: sha512-t9rhmLT6EqeuPT+MXhWhlRYIMSfh5LZ6kBrC4FS6/+M1yXwfCtp24UumgCWOAJVyjQwG+lYva6wWZxrfvB+NhQ==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.10.tgz}
+    resolution: {integrity: sha512-t9rhmLT6EqeuPT+MXhWhlRYIMSfh5LZ6kBrC4FS6/+M1yXwfCtp24UumgCWOAJVyjQwG+lYva6wWZxrfvB+NhQ==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.1.10':
-    resolution: {integrity: sha512-3oWrlNlxLRxXejQ8zImzrVLuZ/9Z2SeKoLhtCu0hpo38hTO2iL86eFOu4sVR8cZc6n3z7eRXXqtHJECa6mFOvA==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.10.tgz}
+    resolution: {integrity: sha512-3oWrlNlxLRxXejQ8zImzrVLuZ/9Z2SeKoLhtCu0hpo38hTO2iL86eFOu4sVR8cZc6n3z7eRXXqtHJECa6mFOvA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.10':
-    resolution: {integrity: sha512-saScU0cmWvg/Ez4gUmQWr9pvY9Kssxt+Xenfx1LG7LmqjcrvBnw4r9VjkFcqmbBb7GCBwYNcZi9X3/oMda9sqQ==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.10.tgz}
+    resolution: {integrity: sha512-saScU0cmWvg/Ez4gUmQWr9pvY9Kssxt+Xenfx1LG7LmqjcrvBnw4r9VjkFcqmbBb7GCBwYNcZi9X3/oMda9sqQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.10':
-    resolution: {integrity: sha512-/G3ao/ybV9YEEgAXeEg28dyH6gs1QG8tvdN9c2MNZdUXYBaIY/Gx0N6RlJzfLy/7Nkdok4kaxKPHKJUlAaoTdA==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.10.tgz}
+    resolution: {integrity: sha512-/G3ao/ybV9YEEgAXeEg28dyH6gs1QG8tvdN9c2MNZdUXYBaIY/Gx0N6RlJzfLy/7Nkdok4kaxKPHKJUlAaoTdA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.10':
-    resolution: {integrity: sha512-LNr7X8fTiKGRtQGOerSayc2pWJp/9ptRYAa4G+U+cjw9kJZvkopav1AQc5HHD+U364f71tZv6XamaHKgrIoVzA==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.10.tgz}
+    resolution: {integrity: sha512-LNr7X8fTiKGRtQGOerSayc2pWJp/9ptRYAa4G+U+cjw9kJZvkopav1AQc5HHD+U364f71tZv6XamaHKgrIoVzA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.10':
-    resolution: {integrity: sha512-d6ekQpopFQJAcIK2i7ZzWOYGZ+A6NzzvQ3ozBvWFdeyqfOZdYHU66g5yr+/HC4ipP1ZgWsqa80+ISNILk+ae/Q==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.10.tgz}
+    resolution: {integrity: sha512-d6ekQpopFQJAcIK2i7ZzWOYGZ+A6NzzvQ3ozBvWFdeyqfOZdYHU66g5yr+/HC4ipP1ZgWsqa80+ISNILk+ae/Q==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -667,13 +650,13 @@ packages:
       - tslib
 
   '@tailwindcss/oxide-win32-arm64-msvc@4.1.10':
-    resolution: {integrity: sha512-i1Iwg9gRbwNVOCYmnigWCCgow8nDWSFmeTUU5nbNx3rqbe4p0kRbEqLwLJbYZKmSSp23g4N6rCDmm7OuPBXhDA==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.10.tgz}
+    resolution: {integrity: sha512-i1Iwg9gRbwNVOCYmnigWCCgow8nDWSFmeTUU5nbNx3rqbe4p0kRbEqLwLJbYZKmSSp23g4N6rCDmm7OuPBXhDA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
   '@tailwindcss/oxide-win32-x64-msvc@4.1.10':
-    resolution: {integrity: sha512-sGiJTjcBSfGq2DVRtaSljq5ZgZS2SDHSIfhOylkBvHVjwOsodBhnb3HdmiKkVuUGKD0I7G63abMOVaskj1KpOA==, tarball: https://registry.npmmirror.com/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.10.tgz}
+    resolution: {integrity: sha512-sGiJTjcBSfGq2DVRtaSljq5ZgZS2SDHSIfhOylkBvHVjwOsodBhnb3HdmiKkVuUGKD0I7G63abMOVaskj1KpOA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -749,6 +732,10 @@ packages:
       supports-color:
         optional: true
 
+  decode-uri-component@0.4.1:
+    resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
+    engines: {node: '>=14.16'}
+
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==, tarball: https://registry.npmmirror.com/detect-libc/-/detect-libc-2.0.4.tgz}
     engines: {node: '>=8'}
@@ -777,8 +764,12 @@ packages:
       picomatch:
         optional: true
 
+  filter-obj@5.1.0:
+    resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
+    engines: {node: '>=14.16'}
+
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz}
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -811,65 +802,61 @@ packages:
     hasBin: true
 
   lightningcss-darwin-arm64@1.30.1:
-    resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==, tarball: https://registry.npmmirror.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz}
+    resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.30.1:
-    resolution: {integrity: sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==, tarball: https://registry.npmmirror.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz}
+    resolution: {integrity: sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
   lightningcss-freebsd-x64@1.30.1:
-    resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==, tarball: https://registry.npmmirror.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz}
+    resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
   lightningcss-linux-arm-gnueabihf@1.30.1:
-    resolution: {integrity: sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==, tarball: https://registry.npmmirror.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz}
+    resolution: {integrity: sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
   lightningcss-linux-arm64-gnu@1.30.1:
-    resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==, tarball: https://registry.npmmirror.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz}
+    resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
-    resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==, tarball: https://registry.npmmirror.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz}
+    resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
-    resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==, tarball: https://registry.npmmirror.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz}
+    resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
-    resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==, tarball: https://registry.npmmirror.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz}
+    resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
-    resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==, tarball: https://registry.npmmirror.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz}
+    resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.30.1:
-    resolution: {integrity: sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==, tarball: https://registry.npmmirror.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz}
+    resolution: {integrity: sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
@@ -880,6 +867,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==, tarball: https://registry.npmmirror.com/lru-cache/-/lru-cache-5.1.1.tgz}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==, tarball: https://registry.npmmirror.com/magic-string/-/magic-string-0.30.17.tgz}
@@ -922,6 +913,10 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==, tarball: https://registry.npmmirror.com/postcss/-/postcss-8.5.6.tgz}
     engines: {node: ^10 || ^12 || >=14}
 
+  query-string@9.2.2:
+    resolution: {integrity: sha512-pDSIZJ9sFuOp6VnD+5IkakSVf+rICAuuU88Hcsr6AKL0QtxSIfVuKiVP2oahFI7tk3CRSexwV+Ya6MOoTxzg9g==}
+    engines: {node: '>=18'}
+
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==, tarball: https://registry.npmmirror.com/react-dom/-/react-dom-19.1.0.tgz}
     peerDependencies:
@@ -950,6 +945,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==, tarball: https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz}
     engines: {node: '>=0.10.0'}
+
+  split-on-first@3.0.0:
+    resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
+    engines: {node: '>=12'}
 
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==, tarball: https://registry.npmmirror.com/state-local/-/state-local-1.0.7.tgz}
@@ -1569,6 +1568,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-uri-component@0.4.1: {}
+
   detect-libc@2.0.4: {}
 
   electron-to-chromium@1.5.171: {}
@@ -1611,6 +1612,8 @@ snapshots:
   fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  filter-obj@5.1.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -1678,6 +1681,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -1707,6 +1712,12 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  query-string@9.2.2:
+    dependencies:
+      decode-uri-component: 0.4.1
+      filter-obj: 5.1.0
+      split-on-first: 3.0.0
 
   react-dom@19.1.0(react@19.1.0):
     dependencies:
@@ -1748,6 +1759,8 @@ snapshots:
   semver@6.3.1: {}
 
   source-map-js@1.2.1: {}
+
+  split-on-first@3.0.0: {}
 
   state-local@1.0.7: {}
 

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -16,7 +16,7 @@ import type { OutputType } from "./types";
 
 function Playground() {
   const {
-    state: { sourceCode, formatOptions },
+    state: { sourceCode, deferredSourceCode, formatOptions },
     setSourceCode,
     setFormatOptions,
   } = usePlaygroundState();
@@ -24,7 +24,11 @@ function Playground() {
 
   // Custom hooks
   const screenSize = useScreenSize();
-  const formatter = useTypstFormatter(sourceCode, formatOptions, activeOutput);
+  const formatter = useTypstFormatter(
+    deferredSourceCode,
+    formatOptions,
+    activeOutput,
+  );
   const shareManager = useShareManager();
 
   const handleEditorChange = (value: string | undefined) => {
@@ -38,6 +42,7 @@ function Playground() {
   };
 
   const handleActiveTabChange = (tabId: string) => {
+    // Only update activeOutput if the tab is an output type
     if (tabId === "formatted" || tabId === "ast" || tabId === "ir") {
       setActiveOutput(tabId);
     }

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -71,7 +71,7 @@ function Playground() {
       key="source-editor"
       value={sourceCode}
       onChange={handleEditorChange}
-      lineLengthGuide={formatOptions.maxLineLength}
+      lineLengthGuide={formatOptions.lineWidth}
     />
   );
   const formattedPanel = (
@@ -79,8 +79,8 @@ function Playground() {
       key="output-formatted"
       content={formatter.formattedCode}
       language="typst"
-      indentSize={formatOptions.indentSize}
-      lineLengthGuide={formatOptions.maxLineLength}
+      indentSize={formatOptions.indentWidth}
+      lineLengthGuide={formatOptions.lineWidth}
     />
   );
   const astPanel = (

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { OutputEditor, SourceEditor } from "./components/editor";
 import { FloatingErrorCard } from "./components/FloatingErrorCard";
 import { SettingsPanel } from "./components/forms/SettingsPanel";
@@ -6,42 +6,26 @@ import { Header } from "./components/Header";
 import { MainLayout } from "./components/MainLayout";
 import { ShareModal } from "./components/ui/ShareModal";
 import { ToastContainer } from "./components/ui/ToastContainer";
-import { DEFAULT_FORMAT_OPTIONS } from "./constants";
-import { useScreenSize, useShareManager, useTypstFormatter } from "./hooks";
-import type { FormatOptions, OutputType } from "./types";
-import { cleanUrlAfterLoad, getStateFromUrl } from "./utils";
+import {
+  usePlaygroundState,
+  useScreenSize,
+  useShareManager,
+  useTypstFormatter,
+} from "./hooks";
+import type { OutputType } from "./types";
 
 function Playground() {
-  const [sourceCode, setSourceCode] = useState("");
-  const [formatOptions, setFormatOptions] = useState<FormatOptions>(
-    DEFAULT_FORMAT_OPTIONS,
-  );
+  const {
+    state: { sourceCode, formatOptions },
+    setSourceCode,
+    setFormatOptions,
+  } = usePlaygroundState();
   const [activeOutput, setActiveOutput] = useState<OutputType>("formatted");
 
   // Custom hooks
   const screenSize = useScreenSize();
   const formatter = useTypstFormatter(sourceCode, formatOptions, activeOutput);
   const shareManager = useShareManager();
-
-  // Load state from URL on component mount
-  useEffect(() => {
-    const loadStateFromUrl = async () => {
-      const urlState = await getStateFromUrl();
-      if (urlState) {
-        setSourceCode(urlState.sourceCode || "");
-        setFormatOptions({
-          ...DEFAULT_FORMAT_OPTIONS,
-          ...urlState.formatOptions,
-        });
-        setActiveOutput(urlState.activeOutput || "formatted");
-
-        // Clean the URL after successfully loading the state
-        cleanUrlAfterLoad();
-      }
-    };
-
-    loadStateFromUrl();
-  }, []);
 
   const handleEditorChange = (value: string | undefined) => {
     if (value !== undefined) {
@@ -54,7 +38,6 @@ function Playground() {
   };
 
   const handleActiveTabChange = (tabId: string) => {
-    // Only update activeOutput if the tab is an output type
     if (tabId === "formatted" || tabId === "ast" || tabId === "ir") {
       setActiveOutput(tabId);
     }
@@ -64,7 +47,6 @@ function Playground() {
     const playgroundState = {
       sourceCode,
       formatOptions,
-      activeOutput,
     };
     await shareManager.generateShare(playgroundState);
   };

--- a/playground/src/components/forms/SettingsPanel.tsx
+++ b/playground/src/components/forms/SettingsPanel.tsx
@@ -10,10 +10,10 @@ export function SettingsPanel({
   formatOptions,
   setFormatOptions,
 }: SettingsPanelProps) {
-  const lineLengthSelectId = useId();
-  const lineLengthInputId = useId();
-  const indentSizeSelectId = useId();
-  const indentSizeInputId = useId();
+  const lineWidthSelectId = useId();
+  const lineWidthInputId = useId();
+  const indentWidthSelectId = useId();
+  const indentWidthInputId = useId();
   const collapseMarkupSpacesId = useId();
   const reorderImportItemsId = useId();
   const wrapTextId = useId();
@@ -25,22 +25,22 @@ export function SettingsPanel({
   return (
     <div className="p-2 overflow-y-auto flex flex-wrap gap-3 text-sm">
       <div className="flex items-center justify-between w-full">
-        <label htmlFor={lineLengthSelectId}>Line Length:</label>
+        <label htmlFor={lineWidthSelectId}>Line Width:</label>
         <div className="flex gap-1 flex-shrink-0">
           <select
-            id={lineLengthSelectId}
+            id={lineWidthSelectId}
             name="lineWidth"
             className="select w-16 px-3"
             value={
-              [40, 60, 80, 100, 120].includes(formatOptions.maxLineLength)
-                ? formatOptions.maxLineLength
+              [40, 60, 80, 100, 120].includes(formatOptions.lineWidth)
+                ? formatOptions.lineWidth
                 : "custom"
             }
             onChange={(e) => {
               if (e.target.value !== "custom") {
                 setFormatOptions((prev) => ({
                   ...prev,
-                  maxLineLength: Number.parseInt(e.target.value),
+                  lineWidth: Number.parseInt(e.target.value),
                 }));
               }
             }}
@@ -57,17 +57,17 @@ export function SettingsPanel({
             <option value={120}>120</option>
           </select>
           <input
-            id={lineLengthInputId}
+            id={lineWidthInputId}
             type="number"
             className="input w-16"
             min="0"
             max="200"
-            aria-label="Custom Line Length"
-            value={formatOptions.maxLineLength}
+            aria-label="Custom Line Width"
+            value={formatOptions.lineWidth}
             onChange={(e) =>
               setFormatOptions((prev) => ({
                 ...prev,
-                maxLineLength: Number.parseInt(e.target.value),
+                lineWidth: Number.parseInt(e.target.value),
               }))
             }
           />
@@ -75,21 +75,21 @@ export function SettingsPanel({
       </div>
 
       <div className="flex items-center justify-between w-full">
-        <label htmlFor={indentSizeSelectId}>Indent:</label>
+        <label htmlFor={indentWidthSelectId}>Indent:</label>
         <div className="flex gap-1 flex-shrink-0">
           <select
-            id={indentSizeSelectId}
+            id={indentWidthSelectId}
             name="indentSize"
             className="select w-16 px-3"
             value={
-              [2, 4, 8].includes(formatOptions.indentSize)
-                ? formatOptions.indentSize
+              [2, 4, 8].includes(formatOptions.indentWidth)
+                ? formatOptions.indentWidth
                 : "custom"
             }
             onChange={(e) => {
               setFormatOptions((prev) => ({
                 ...prev,
-                indentSize: Number.parseInt(e.target.value),
+                indentWidth: Number.parseInt(e.target.value),
               }));
             }}
           >
@@ -101,17 +101,17 @@ export function SettingsPanel({
             <option value={8}>8</option>
           </select>
           <input
-            id={indentSizeInputId}
+            id={indentWidthInputId}
             type="number"
             className="input w-16"
             min="1"
             max="16"
             aria-label="Custom Indent Size"
-            value={formatOptions.indentSize}
+            value={formatOptions.indentWidth}
             onChange={(e) =>
               setFormatOptions((prev) => ({
                 ...prev,
-                indentSize: Number.parseInt(e.target.value),
+                indentWidth: Number.parseInt(e.target.value),
               }))
             }
           />

--- a/playground/src/components/forms/SettingsPanel.tsx
+++ b/playground/src/components/forms/SettingsPanel.tsx
@@ -1,6 +1,5 @@
 import { useId } from "react";
-import { DEFAULT_FORMAT_OPTIONS } from "@/constants";
-import type { FormatOptions } from "@/types";
+import { DEFAULT_FORMAT_OPTIONS, type FormatOptions } from "@/utils/formatter";
 
 interface SettingsPanelProps {
   formatOptions: FormatOptions;

--- a/playground/src/components/forms/SettingsPanel.tsx
+++ b/playground/src/components/forms/SettingsPanel.tsx
@@ -49,6 +49,8 @@ export function SettingsPanel({
             <option value="custom" disabled>
               Custom
             </option>
+            <option value={0}>0</option>
+            <option value={20}>20</option>
             <option value={40}>40</option>
             <option value={60}>60</option>
             <option value={80}>80</option>

--- a/playground/src/constants.ts
+++ b/playground/src/constants.ts
@@ -1,17 +1,6 @@
-import type { FormatOptions } from "./types";
-
 // Sample Typst documents for testing
 export const SAMPLE_DOCUMENTS: {
   [key: string]: { name: string; filePath: URL };
 } = {
   // TODO: add samples
 } as const;
-
-// Default format style options
-export const DEFAULT_FORMAT_OPTIONS: FormatOptions = {
-  maxLineLength: 80,
-  indentSize: 2,
-  collapseMarkupSpaces: false,
-  reorderImportItems: true,
-  wrapText: false,
-};

--- a/playground/src/hooks/index.ts
+++ b/playground/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { usePlaygroundState } from "./use-playground-state";
 export { useScreenSize } from "./use-screen-size";
 export { useTheme } from "./use-theme";
 export { useTypstFormatter } from "./use-typst-formatter";

--- a/playground/src/hooks/use-playground-state.ts
+++ b/playground/src/hooks/use-playground-state.ts
@@ -1,0 +1,88 @@
+import { useDeferredValue, useEffect, useState } from "react";
+import { DEFAULT_FORMAT_OPTIONS } from "../constants";
+import type { FormatOptions } from "../types";
+import { cleanUrlAfterLoad, getStateFromUrl } from "../utils";
+
+const STORAGE_KEY = "typstyle-playground-state";
+
+export interface PlaygroundState {
+  sourceCode: string;
+  formatOptions: FormatOptions;
+}
+
+export function usePlaygroundState() {
+  const [sourceCode, setSourceCode] = useState("");
+  const [formatOptions, setFormatOptions] = useState(DEFAULT_FORMAT_OPTIONS);
+
+  // Use deferred value for source code throttling
+  const deferredSourceCode = useDeferredValue(sourceCode);
+
+  // Load state on mount
+  useEffect(() => {
+    const loadState = async () => {
+      try {
+        const urlState = await getStateFromUrl();
+        if (urlState) {
+          setSourceCode(urlState.sourceCode || "");
+          setFormatOptions({
+            ...DEFAULT_FORMAT_OPTIONS,
+            ...urlState.formatOptions,
+          });
+          cleanUrlAfterLoad();
+          return;
+        }
+
+        const savedState = localStorage.getItem(STORAGE_KEY);
+        if (savedState) {
+          const parsed = JSON.parse(savedState);
+          setSourceCode(parsed.sourceCode || "");
+          setFormatOptions({
+            ...DEFAULT_FORMAT_OPTIONS,
+            ...parsed.formatOptions,
+          });
+        }
+      } catch (error) {
+        console.error("Error loading state:", error);
+      }
+    };
+
+    loadState();
+  }, []);
+
+  // Save state to localStorage (throttled for source code, only non-default options)
+  useEffect(() => {
+    // Build state with only non-default options
+    const stateToSave: {
+      sourceCode?: string;
+      formatOptions?: Partial<FormatOptions>;
+    } = {};
+
+    if (deferredSourceCode !== "") {
+      stateToSave.sourceCode = deferredSourceCode;
+    }
+
+    // Only include format options that differ from defaults
+    const nondefaultOptions: Partial<FormatOptions> = Object.fromEntries(
+      Object.entries(formatOptions).filter(
+        ([key, value]) =>
+          value !==
+          DEFAULT_FORMAT_OPTIONS[key as keyof typeof DEFAULT_FORMAT_OPTIONS],
+      ),
+    );
+    if (Object.keys(nondefaultOptions).length > 0) {
+      stateToSave.formatOptions = nondefaultOptions;
+    }
+
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(stateToSave));
+    } catch (error) {
+      console.error("Error saving to localStorage:", error);
+    }
+  }, [deferredSourceCode, formatOptions]);
+
+  return {
+    state: { sourceCode, formatOptions },
+    setSourceCode,
+    setFormatOptions,
+  };
+}

--- a/playground/src/hooks/use-playground-state.ts
+++ b/playground/src/hooks/use-playground-state.ts
@@ -1,6 +1,9 @@
 import { useDeferredValue, useEffect, useState } from "react";
-import { DEFAULT_FORMAT_OPTIONS } from "../constants";
-import type { FormatOptions } from "../types";
+import {
+  DEFAULT_FORMAT_OPTIONS,
+  type FormatOptions,
+  filterNonDefaultOptions,
+} from "@/utils/formatter";
 import { cleanUrlAfterLoad, getStateFromUrl } from "../utils";
 
 const STORAGE_KEY = "typstyle-playground-state";
@@ -62,13 +65,7 @@ export function usePlaygroundState() {
     }
 
     // Only include format options that differ from defaults
-    const nondefaultOptions: Partial<FormatOptions> = Object.fromEntries(
-      Object.entries(formatOptions).filter(
-        ([key, value]) =>
-          value !==
-          DEFAULT_FORMAT_OPTIONS[key as keyof typeof DEFAULT_FORMAT_OPTIONS],
-      ),
-    );
+    const nondefaultOptions = filterNonDefaultOptions(formatOptions);
     if (Object.keys(nondefaultOptions).length > 0) {
       stateToSave.formatOptions = nondefaultOptions;
     }

--- a/playground/src/hooks/use-playground-state.ts
+++ b/playground/src/hooks/use-playground-state.ts
@@ -25,7 +25,7 @@ export function usePlaygroundState() {
     const loadState = async () => {
       try {
         const urlState = await getStateFromUrl();
-        console.log("load state", urlState);
+        console.debug("load state", urlState);
         if (urlState) {
           setSourceCode(urlState.sourceCode);
           setFormatOptions({

--- a/playground/src/hooks/use-playground-state.ts
+++ b/playground/src/hooks/use-playground-state.ts
@@ -42,7 +42,7 @@ export function usePlaygroundState() {
     loadState();
   }, []);
 
-  // Save state to localStorage and update URL (only non-default options)
+  // Save state to URL (only non-default options)
   useEffect(() => {
     if (!initialized.current) {
       // To avoid url state being overridden
@@ -55,7 +55,7 @@ export function usePlaygroundState() {
   }, [deferredSourceCode, formatOptions]);
 
   return {
-    state: { sourceCode, formatOptions },
+    state: { sourceCode, deferredSourceCode, formatOptions },
     setSourceCode,
     setFormatOptions,
   };

--- a/playground/src/hooks/use-typst-formatter.ts
+++ b/playground/src/hooks/use-typst-formatter.ts
@@ -1,7 +1,7 @@
 import { useDeferredValue, useEffect, useState } from "react";
 import * as typstyle from "typstyle-wasm";
 import type { OutputType } from "@/types";
-import type { FormatOptions } from "@/utils/formatter";
+import { type FormatOptions, formatOptionsToConfig } from "@/utils/formatter";
 
 export interface Formatter {
   formattedCode: string;
@@ -23,13 +23,7 @@ export function useTypstFormatter(
   const [error, setError] = useState<string | null>(null);
 
   const formatCode = async () => {
-    const config: Partial<typstyle.Config> = {
-      max_width: formatOptions.maxLineLength,
-      tab_spaces: formatOptions.indentSize,
-      collapse_markup_spaces: formatOptions.collapseMarkupSpaces,
-      reorder_import_items: formatOptions.reorderImportItems,
-      wrap_text: formatOptions.wrapText,
-    };
+    const config = formatOptionsToConfig(formatOptions);
 
     try {
       // Only call the WASM function for the currently active output

--- a/playground/src/hooks/use-typst-formatter.ts
+++ b/playground/src/hooks/use-typst-formatter.ts
@@ -1,4 +1,4 @@
-import { useDeferredValue, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import * as typstyle from "typstyle-wasm";
 import type { OutputType } from "@/types";
 import { type FormatOptions, formatOptionsToConfig } from "@/utils/formatter";
@@ -16,7 +16,6 @@ export function useTypstFormatter(
   formatOptions: FormatOptions,
   activeOutput: OutputType,
 ): Formatter {
-  const deferredSourceCode = useDeferredValue(sourceCode);
   const [formattedCode, setFormattedCode] = useState("");
   const [astOutput, setAstOutput] = useState("");
   const [irOutput, setIrOutput] = useState("");
@@ -29,7 +28,7 @@ export function useTypstFormatter(
       // Only call the WASM function for the currently active output
       switch (activeOutput) {
         case "formatted": {
-          const formatted = typstyle.format(deferredSourceCode, config);
+          const formatted = typstyle.format(sourceCode, config);
           setFormattedCode(formatted);
 
           // Check for convergence on formatted output
@@ -47,13 +46,13 @@ export function useTypstFormatter(
           break;
         }
         case "ast": {
-          const ast = typstyle.parse(deferredSourceCode);
+          const ast = typstyle.parse(sourceCode);
           setAstOutput(ast);
           setError(null);
           break;
         }
         case "ir": {
-          const formatIr = typstyle.format_ir(deferredSourceCode, config);
+          const formatIr = typstyle.format_ir(sourceCode, config);
           setIrOutput(formatIr);
           setError(null);
           break;
@@ -67,7 +66,7 @@ export function useTypstFormatter(
 
   useEffect(() => {
     formatCode();
-  }, [deferredSourceCode, formatOptions, activeOutput]);
+  }, [sourceCode, formatOptions, activeOutput]);
 
   return {
     formattedCode,

--- a/playground/src/hooks/use-typst-formatter.ts
+++ b/playground/src/hooks/use-typst-formatter.ts
@@ -1,6 +1,7 @@
 import { useDeferredValue, useEffect, useState } from "react";
 import * as typstyle from "typstyle-wasm";
-import type { FormatOptions, OutputType } from "@/types";
+import type { OutputType } from "@/types";
+import type { FormatOptions } from "@/utils/formatter";
 
 export interface Formatter {
   formattedCode: string;

--- a/playground/src/hooks/useShareManager.ts
+++ b/playground/src/hooks/useShareManager.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
-import type { PlaygroundState } from "@/utils/url";
-import { generateShareUrl } from "@/utils/url";
+import { generateShareUrl, type PlaygroundState } from "@/utils/url";
 import { useToast } from ".";
 
 export interface ShareState {

--- a/playground/src/hooks/useShareManager.ts
+++ b/playground/src/hooks/useShareManager.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
-import type { PlaygroundState } from "@/utils";
-import { copyToClipboard, generateShareUrl } from "@/utils";
+import type { PlaygroundState } from "@/utils/url";
+import { generateShareUrl } from "@/utils/url";
 import { useToast } from ".";
 
 export interface ShareState {
@@ -105,4 +105,20 @@ export function useShareManager() {
     closeModal,
     resetError,
   };
+}
+
+/**
+ * Copies text to the clipboard using modern API
+ */
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+    throw new Error("Clipboard API not available");
+  } catch (error) {
+    console.error("Error copying to clipboard:", error);
+    return false;
+  }
 }

--- a/playground/src/types.ts
+++ b/playground/src/types.ts
@@ -5,11 +5,3 @@ export type ThemeType = "light" | "dark";
 export type ScreenSizeType = "wide" | "thin";
 
 export type OutputType = "formatted" | "ast" | "ir";
-
-export interface FormatOptions {
-  maxLineLength: number;
-  indentSize: number;
-  collapseMarkupSpaces: boolean;
-  reorderImportItems: boolean;
-  wrapText: boolean;
-}

--- a/playground/src/utils/formatter.ts
+++ b/playground/src/utils/formatter.ts
@@ -1,0 +1,31 @@
+export interface FormatOptions {
+  maxLineLength: number;
+  indentSize: number;
+  collapseMarkupSpaces: boolean;
+  reorderImportItems: boolean;
+  wrapText: boolean;
+}
+
+// Default format style options
+export const DEFAULT_FORMAT_OPTIONS: FormatOptions = {
+  maxLineLength: 80,
+  indentSize: 2,
+  collapseMarkupSpaces: false,
+  reorderImportItems: true,
+  wrapText: false,
+};
+
+/**
+ * Filters format options to only include non-default values
+ */
+export function filterNonDefaultOptions(
+  options: FormatOptions,
+): Partial<FormatOptions> {
+  return Object.fromEntries(
+    Object.entries(options).filter(
+      ([key, value]) =>
+        value !==
+        DEFAULT_FORMAT_OPTIONS[key as keyof typeof DEFAULT_FORMAT_OPTIONS],
+    ),
+  );
+}

--- a/playground/src/utils/formatter.ts
+++ b/playground/src/utils/formatter.ts
@@ -1,8 +1,8 @@
 import * as typstyle from "typstyle-wasm";
 
 export interface FormatOptions {
-  maxLineLength: number;
-  indentSize: number;
+  lineWidth: number;
+  indentWidth: number;
   collapseMarkupSpaces: boolean;
   reorderImportItems: boolean;
   wrapText: boolean;
@@ -10,8 +10,8 @@ export interface FormatOptions {
 
 // Default format style options
 export const DEFAULT_FORMAT_OPTIONS: FormatOptions = {
-  maxLineLength: 80,
-  indentSize: 2,
+  lineWidth: 80,
+  indentWidth: 2,
   collapseMarkupSpaces: false,
   reorderImportItems: true,
   wrapText: false,
@@ -39,8 +39,8 @@ export function formatOptionsToConfig(
   options: FormatOptions,
 ): Partial<typstyle.Config> {
   return {
-    max_width: options.maxLineLength,
-    tab_spaces: options.indentSize,
+    max_width: options.lineWidth,
+    tab_spaces: options.indentWidth,
     collapse_markup_spaces: options.collapseMarkupSpaces,
     reorder_import_items: options.reorderImportItems,
     wrap_text: options.wrapText,

--- a/playground/src/utils/formatter.ts
+++ b/playground/src/utils/formatter.ts
@@ -1,3 +1,5 @@
+import * as typstyle from "typstyle-wasm";
+
 export interface FormatOptions {
   maxLineLength: number;
   indentSize: number;
@@ -28,4 +30,19 @@ export function filterNonDefaultOptions(
         DEFAULT_FORMAT_OPTIONS[key as keyof typeof DEFAULT_FORMAT_OPTIONS],
     ),
   );
+}
+
+/**
+ * Converts FormatOptions to typstyle configuration
+ */
+export function formatOptionsToConfig(
+  options: FormatOptions,
+): Partial<typstyle.Config> {
+  return {
+    max_width: options.maxLineLength,
+    tab_spaces: options.indentSize,
+    collapse_markup_spaces: options.collapseMarkupSpaces,
+    reorder_import_items: options.reorderImportItems,
+    wrap_text: options.wrapText,
+  };
 }

--- a/playground/src/utils/index.ts
+++ b/playground/src/utils/index.ts
@@ -1,2 +1,0 @@
-export * from "./sample-loader";
-export * from "./url";

--- a/playground/src/utils/pastebin.ts
+++ b/playground/src/utils/pastebin.ts
@@ -1,0 +1,54 @@
+// shz.al API base URL
+const PASTEBIN_API = "https://shz.al";
+
+/**
+ * Upload content to shz.al pastebin
+ */
+export async function uploadToPastebin(
+  content: string,
+): Promise<string | null> {
+  try {
+    const formData = new FormData();
+    formData.append("c", content);
+
+    const response = await fetch(PASTEBIN_API, {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const result = await response.json();
+    if (result.url) {
+      // Extract the paste ID from the URL (e.g., "https://shz.al/abcd" -> "abcd")
+      return (result.url as string).split("/").pop() ?? null;
+    }
+
+    return null;
+  } catch (error) {
+    console.error("Error uploading to pastebin:", error);
+    return null;
+  }
+}
+
+/**
+ * Fetch content from shz.al pastebin
+ */
+export async function fetchFromPastebin(
+  pasteId: string,
+): Promise<string | null> {
+  try {
+    const response = await fetch(`${PASTEBIN_API}/${pasteId}`);
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return await response.text();
+  } catch (error) {
+    console.error("Error fetching from pastebin:", error);
+    return null;
+  }
+}

--- a/playground/src/utils/url.ts
+++ b/playground/src/utils/url.ts
@@ -1,6 +1,6 @@
 import * as lz from "lz-string";
 import queryString from "query-string";
-import { type FormatOptions } from "./formatter";
+import { DEFAULT_FORMAT_OPTIONS, type FormatOptions } from "./formatter";
 import { fetchFromPastebin, uploadToPastebin } from "./pastebin";
 
 export interface PlaygroundState {
@@ -72,12 +72,13 @@ export async function getStateFromUrl(): Promise<PlaygroundState | null> {
   }
 
   // Parse options from query params (use current URL state)
-  params.delete("code");
-  params.delete("paste");
-  const query = queryString.parse(url.search, {
-    parseBooleans: true,
-    parseNumbers: true,
-  });
+  const query = queryString.parse(
+    queryString.pick(url.search, Object.keys(DEFAULT_FORMAT_OPTIONS)),
+    {
+      parseBooleans: true,
+      parseNumbers: true,
+    },
+  );
 
   return {
     sourceCode,

--- a/playground/src/utils/url.ts
+++ b/playground/src/utils/url.ts
@@ -10,7 +10,7 @@ export interface PlaygroundState {
 
 // Maximum URL length before using pastebin for source code storage
 // We use a shorter (< 2048) length to avoid verbosity
-const MAX_URL_LENGTH = 256;
+const MAX_URL_LENGTH = 1024;
 
 /**
  * Updates the URL with current options and source code

--- a/playground/src/utils/url.ts
+++ b/playground/src/utils/url.ts
@@ -1,4 +1,8 @@
-import type { FormatOptions } from "../types";
+import {
+  DEFAULT_FORMAT_OPTIONS,
+  type FormatOptions,
+  filterNonDefaultOptions,
+} from "./formatter";
 
 export interface PlaygroundState {
   sourceCode: string;
@@ -66,9 +70,10 @@ async function fetchFromPastebin(pasteId: string): Promise<string | null> {
 export async function generateShareUrl(
   state: PlaygroundState,
 ): Promise<{ url: string; usedPastebin: boolean }> {
+  const filteredOptions = filterNonDefaultOptions(state.formatOptions);
   const stateString = JSON.stringify({
     c: state.sourceCode,
-    f: state.formatOptions,
+    f: Object.keys(filteredOptions).length > 0 ? filteredOptions : undefined,
   });
   const encoded = encodeURIComponent(stateString);
 
@@ -128,7 +133,7 @@ export async function getStateFromUrl(): Promise<PlaygroundState | null> {
     // Handle the compact format from pastebin
     return {
       sourceCode: parsed.c ?? "",
-      formatOptions: parsed.f ?? {},
+      formatOptions: { ...DEFAULT_FORMAT_OPTIONS, ...parsed.f },
     };
   } catch (error) {
     console.error("Error parsing pastebin content:", error);

--- a/playground/src/utils/url.ts
+++ b/playground/src/utils/url.ts
@@ -3,7 +3,6 @@ import type { FormatOptions, OutputType } from "../types";
 export interface PlaygroundState {
   sourceCode: string;
   formatOptions: FormatOptions;
-  activeOutput: OutputType;
 }
 
 // Maximum URL length before using pastebin (browsers generally support 2000+ chars safely)
@@ -121,7 +120,6 @@ export function encodePlaygroundState(state: PlaygroundState): string {
     const compactState = {
       c: state.sourceCode,
       f: state.formatOptions,
-      o: state.activeOutput,
     };
 
     const stateString = JSON.stringify(compactState);
@@ -147,7 +145,6 @@ export function decodePlaygroundState(encoded: string): PlaygroundState | null {
       return {
         sourceCode: parsed.c || "",
         formatOptions: parsed.f || {},
-        activeOutput: parsed.o || "formatted",
       };
     }
 
@@ -155,7 +152,6 @@ export function decodePlaygroundState(encoded: string): PlaygroundState | null {
     return {
       sourceCode: parsed.sourceCode || "",
       formatOptions: parsed.formatOptions || {},
-      activeOutput: parsed.activeOutput || "formatted",
     };
   } catch (error) {
     console.error("Error decoding playground state:", error);
@@ -189,7 +185,6 @@ export async function generateShareUrl(
   const stateString = JSON.stringify({
     c: state.sourceCode,
     f: state.formatOptions,
-    o: state.activeOutput,
   });
 
   const pasteId = await uploadToPastebin(stateString);
@@ -232,7 +227,6 @@ export async function getStateFromUrl(): Promise<PlaygroundState | null> {
       return {
         sourceCode: parsed.c || "",
         formatOptions: parsed.f || {},
-        activeOutput: parsed.o || "formatted",
       };
     } catch (error) {
       console.error("Error parsing pastebin content:", error);


### PR DESCRIPTION
Now url query params are dynamically updated with format options and code (using lz-string compression). So, we can use the current URL as sharing link and serve the purpose of persistence.

Only code is uploaded to the pastebin when the URL to share is too long.