### PR TITLE
fix: prevent breaking before enum marker-like texts

### DIFF
--- a/crates/typstyle-core/src/pretty/markup.rs
+++ b/crates/typstyle-core/src/pretty/markup.rs
@@ -2,7 +2,8 @@ use smallvec::SmallVec;
 use typst_syntax::{ast::*, SyntaxKind, SyntaxNode};
 
 use super::{
-    layout::flow::FlowItem, prelude::*, util::is_comment_node, Context, Mode, PrettyPrinter,
+    layout::flow::FlowItem, prelude::*, text::is_enum_marker, util::is_comment_node, Context, Mode,
+    PrettyPrinter,
 };
 use crate::ext::StrExt;
 
@@ -289,8 +290,10 @@ impl<'a> PrettyPrinter<'a> {
         ///
         /// Besides, reflowing labels to the next line is not desired.
         fn cannot_break_before(node: &&SyntaxNode) -> bool {
-            matches!(node.text().as_str(), "=" | "+" | "-" | "/")
+            let text = node.text();
+            matches!(text.as_str(), "=" | "+" | "-" | "/")
                 || matches!(node.kind(), SyntaxKind::Label)
+                || is_enum_marker(text)
         }
 
         /// For space -> hard-line: \

--- a/crates/typstyle-core/src/pretty/text.rs
+++ b/crates/typstyle-core/src/pretty/text.rs
@@ -37,12 +37,66 @@ impl<'a> PrettyPrinter<'a> {
     }
 }
 
+/// Wraps `text` into a `ArenaDoc`, using `softline()` between words,
+/// except before tokens that can be parsed as enum markers, where we use a hard space.
+///
+/// See: https://github.com/typst/typst/blob/8ace67d942a4b8c6b9d95b73b3a39f5d0259c7b2/crates/typst-syntax/src/lexer.rs#L479-L488
 fn wrap_text<'a>(arena: &'a Arena<'a>, text: &'a str) -> ArenaDoc<'a> {
-    arena.intersperse(text.split_ascii_whitespace(), arena.softline())
-        + if text.ends_with(' ') {
-            // special case when a link follows the text
-            arena.softline()
+    let mut tokens = text.split_ascii_whitespace();
+    // start with first token (or nil() if empty)
+    let mut doc = if let Some(first) = tokens.next() {
+        arena.text(first)
+    } else {
+        return arena.nil();
+    };
+
+    // fold over the rest
+    doc = tokens.fold(doc, |doc, token| {
+        let sep = if is_enum_marker(token) {
+            arena.space()
         } else {
-            arena.nil()
-        }
+            arena.softline()
+        };
+        doc + sep + arena.text(token)
+    });
+
+    // preserve a trailing space as a final softline
+    // special case when a link follows the text
+    if text.ends_with(' ') {
+        doc += arena.softline();
+    }
+
+    doc
+}
+
+/// Returns `true` if `token` is one or more ASCII digits that parse as a `usize`, followed by a dot.
+/// Examples: "1.", "42.",
+pub(super) fn is_enum_marker(token: &str) -> bool {
+    // Check and strip trailing dot
+    if let Some(stripped) = token.strip_suffix('.') {
+        // Attempt to parse the digits as a `usize`
+        return stripped.parse::<usize>().is_ok();
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    #[test]
+    fn enum_marker_glues() {
+        let text = "a. 1. 01. 18446744073709551615. 18446744073709551616. 18446744073709551617.";
+
+        let arena = Arena::new();
+        let doc = wrap_text(&arena, text);
+
+        assert_snapshot!(doc.print(0).to_string(), @r"
+        a. 1. 01. 18446744073709551615.
+        18446744073709551616.
+        18446744073709551617.
+        ")
+    }
 }

--- a/tests/fixtures/unit/markup/reflow/general.typ
+++ b/tests/fixtures/unit/markup/reflow/general.typ
@@ -141,3 +141,10 @@ This might be yet a bit cleaner.
 #highlight[Actually, it's muuuuuch worse in
 performance. Moreover the first version can be optimized to compute many marks
 at once. ]
+
+// Special characters that form syntax
+Text with -- en-dash and --- em-dash.
+
+// Escape sequences
+Text with \\ backslash and \* escaped asterisk.
+Newline escape \n and tab \t characters.

--- a/tests/fixtures/unit/markup/reflow/marker.typ
+++ b/tests/fixtures/unit/markup/reflow/marker.typ
@@ -1,0 +1,48 @@
+/// typstyle: wrap_text
+// Focus: prevent normal text "1." from being reflowed to create false enum items
+
+// === BASIC CASES ===
+Version 0.
+Text with version 1. followed by chapter 2. and section 3. all in one paragraph.
+References to items 4. and 5. and 6. should stay together.
+
+// === SPACING VARIATIONS ===
+// Spaces AFTER markers
+Normal text ending 1. with single space.
+Text ending 2.  with double space.
+Line ending 3.	with tab.
+
+// Spaces BEFORE markers
+Word 4. Single space before marker.
+Word  5. Double space before marker.
+Word	6. Tab before marker.
+
+// Spaces BOTH before and after markers
+Text  7.  double before and after.
+Text	8.	tab before and after.
+Text  9.   mixed double before, triple after.
+
+// === NON-ENUM MARKERS ===
+// These can break normally
+a. This can break normally.
+1.5 This is not an enum marker.
+1.. This has double dots.
+v1.0 Version numbers can break.
+
+// === EDGE CASES ===
+-1. 00. 01.
+Text about version 18446744073709551615. should stay glued.
+Reference to item 18446744073709551616. should break (overflow).
+
+// Punctuation after potential markers
+Sentence about version 1. (with parentheses).
+Text mentioning chapter 2. "with quotes".
+Discussion of point 3. *with emphasis*.
+Reference to section 4. `with code`.
+Price is \$5. New sentence starts here.
+
+// === enum markers ===
+01. Item with leading zero.
+007. Another item with leading zeros.
+18446744073709551615. That's OK
+18446744073709551616. This will overflow

--- a/tests/fixtures/unit/markup/reflow/snap/general.typ-0.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/general.typ-0.snap
@@ -632,3 +632,29 @@ cleaner.
   at
   once.
 ]
+
+// Special characters that form syntax
+Text
+with
+--
+en-dash
+and
+---
+em-dash.
+
+// Escape sequences
+Text
+with
+\\
+backslash
+and
+\*
+escaped
+asterisk.
+Newline
+escape
+\n
+and
+tab
+\t
+characters.

--- a/tests/fixtures/unit/markup/reflow/snap/general.typ-120.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/general.typ-120.snap
@@ -131,3 +131,9 @@ This might be yet a bit cleaner.
 #highlight[Actually, it's muuuuuch worse in performance. Moreover the first version can be optimized to compute many
   marks at once.
 ]
+
+// Special characters that form syntax
+Text with -- en-dash and --- em-dash.
+
+// Escape sequences
+Text with \\ backslash and \* escaped asterisk. Newline escape \n and tab \t characters.

--- a/tests/fixtures/unit/markup/reflow/snap/general.typ-40.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/general.typ-40.snap
@@ -209,3 +209,11 @@ This might be yet a bit cleaner.
   version can be optimized to compute
   many marks at once.
 ]
+
+// Special characters that form syntax
+Text with -- en-dash and --- em-dash.
+
+// Escape sequences
+Text with \\ backslash and \* escaped
+asterisk. Newline escape \n and tab \t
+characters.

--- a/tests/fixtures/unit/markup/reflow/snap/general.typ-80.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/general.typ-80.snap
@@ -144,3 +144,10 @@ This might be yet a bit cleaner.
 #highlight[Actually, it's muuuuuch worse in performance. Moreover the first
   version can be optimized to compute many marks at once.
 ]
+
+// Special characters that form syntax
+Text with -- en-dash and --- em-dash.
+
+// Escape sequences
+Text with \\ backslash and \* escaped asterisk. Newline escape \n and tab \t
+characters.

--- a/tests/fixtures/unit/markup/reflow/snap/marker.typ-0.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/marker.typ-0.snap
@@ -1,0 +1,167 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/markup/reflow/marker.typ
+---
+/// typstyle: wrap_text
+// Focus: prevent normal text "1." from being reflowed to create false enum items
+
+// === BASIC CASES ===
+Version 0.
+Text
+with
+version 1.
+followed
+by
+chapter 2.
+and
+section 3.
+all
+in
+one
+paragraph.
+References
+to
+items 4.
+and 5.
+and 6.
+should
+stay
+together.
+
+// === SPACING VARIATIONS ===
+// Spaces AFTER markers
+Normal
+text
+ending 1.
+with
+single
+space.
+Text
+ending 2.
+with
+double
+space.
+Line
+ending 3.
+with
+tab.
+
+// Spaces BEFORE markers
+Word 4.
+Single
+space
+before
+marker.
+Word 5.
+Double
+space
+before
+marker.
+Word 6.
+Tab
+before
+marker.
+
+// Spaces BOTH before and after markers
+Text 7.
+double
+before
+and
+after.
+Text 8.
+tab
+before
+and
+after.
+Text 9.
+mixed
+double
+before,
+triple
+after.
+
+// === NON-ENUM MARKERS ===
+// These can break normally
+a.
+This
+can
+break
+normally.
+1.5
+This
+is
+not
+an
+enum
+marker.
+1..
+This
+has
+double
+dots.
+v1.0
+Version
+numbers
+can
+break.
+
+// === EDGE CASES ===
+-1. 00. 01.
+Text
+about
+version 18446744073709551615.
+should
+stay
+glued.
+Reference
+to
+item
+18446744073709551616.
+should
+break
+(overflow).
+
+// Punctuation after potential markers
+Sentence
+about
+version 1.
+(with
+parentheses).
+Text
+mentioning
+chapter 2.
+"with
+quotes".
+Discussion
+of
+point 3.
+*with
+emphasis*.
+Reference
+to
+section 4.
+`with code`.
+Price
+is
+\$5.
+New
+sentence
+starts
+here.
+
+// === enum markers ===
+01. Item
+  with
+  leading
+  zero.
+007. Another
+  item
+  with
+  leading
+  zeros.
+18446744073709551615. That's
+  OK
+18446744073709551616.
+This
+will
+overflow

--- a/tests/fixtures/unit/markup/reflow/snap/marker.typ-120.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/marker.typ-120.snap
@@ -1,0 +1,38 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/markup/reflow/marker.typ
+---
+/// typstyle: wrap_text
+// Focus: prevent normal text "1." from being reflowed to create false enum items
+
+// === BASIC CASES ===
+Version 0. Text with version 1. followed by chapter 2. and section 3. all in one paragraph. References to items 4.
+and 5. and 6. should stay together.
+
+// === SPACING VARIATIONS ===
+// Spaces AFTER markers
+Normal text ending 1. with single space. Text ending 2. with double space. Line ending 3. with tab.
+
+// Spaces BEFORE markers
+Word 4. Single space before marker. Word 5. Double space before marker. Word 6. Tab before marker.
+
+// Spaces BOTH before and after markers
+Text 7. double before and after. Text 8. tab before and after. Text 9. mixed double before, triple after.
+
+// === NON-ENUM MARKERS ===
+// These can break normally
+a. This can break normally. 1.5 This is not an enum marker. 1.. This has double dots. v1.0 Version numbers can break.
+
+// === EDGE CASES ===
+-1. 00. 01. Text about version 18446744073709551615. should stay glued. Reference to item 18446744073709551616. should
+break (overflow).
+
+// Punctuation after potential markers
+Sentence about version 1. (with parentheses). Text mentioning chapter 2. "with quotes". Discussion of point 3. *with
+emphasis*. Reference to section 4. `with code`. Price is \$5. New sentence starts here.
+
+// === enum markers ===
+01. Item with leading zero.
+007. Another item with leading zeros.
+18446744073709551615. That's OK
+18446744073709551616. This will overflow

--- a/tests/fixtures/unit/markup/reflow/snap/marker.typ-40.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/marker.typ-40.snap
@@ -1,0 +1,55 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/markup/reflow/marker.typ
+---
+/// typstyle: wrap_text
+// Focus: prevent normal text "1." from being reflowed to create false enum items
+
+// === BASIC CASES ===
+Version 0. Text with version 1. followed
+by chapter 2. and section 3. all in one
+paragraph. References to items 4. and 5.
+and 6. should stay together.
+
+// === SPACING VARIATIONS ===
+// Spaces AFTER markers
+Normal text ending 1. with single space.
+Text ending 2. with double space. Line
+ending 3. with tab.
+
+// Spaces BEFORE markers
+Word 4. Single space before marker.
+Word 5. Double space before marker.
+Word 6. Tab before marker.
+
+// Spaces BOTH before and after markers
+Text 7. double before and after. Text 8.
+tab before and after. Text 9. mixed
+double before, triple after.
+
+// === NON-ENUM MARKERS ===
+// These can break normally
+a. This can break normally. 1.5 This is
+not an enum marker. 1.. This has double
+dots. v1.0 Version numbers can break.
+
+// === EDGE CASES ===
+-1. 00. 01. Text about
+version 18446744073709551615. should
+stay glued. Reference to item
+18446744073709551616. should break
+(overflow).
+
+// Punctuation after potential markers
+Sentence about version 1. (with
+parentheses). Text mentioning chapter 2.
+"with quotes". Discussion of point 3.
+*with emphasis*. Reference to section 4.
+`with code`. Price is \$5. New sentence
+starts here.
+
+// === enum markers ===
+01. Item with leading zero.
+007. Another item with leading zeros.
+18446744073709551615. That's OK
+18446744073709551616. This will overflow

--- a/tests/fixtures/unit/markup/reflow/snap/marker.typ-80.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/marker.typ-80.snap
@@ -1,0 +1,43 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/markup/reflow/marker.typ
+---
+/// typstyle: wrap_text
+// Focus: prevent normal text "1." from being reflowed to create false enum items
+
+// === BASIC CASES ===
+Version 0. Text with version 1. followed by chapter 2. and section 3. all in one
+paragraph. References to items 4. and 5. and 6. should stay together.
+
+// === SPACING VARIATIONS ===
+// Spaces AFTER markers
+Normal text ending 1. with single space. Text ending 2. with double space. Line
+ending 3. with tab.
+
+// Spaces BEFORE markers
+Word 4. Single space before marker. Word 5. Double space before marker. Word 6.
+Tab before marker.
+
+// Spaces BOTH before and after markers
+Text 7. double before and after. Text 8. tab before and after. Text 9. mixed
+double before, triple after.
+
+// === NON-ENUM MARKERS ===
+// These can break normally
+a. This can break normally. 1.5 This is not an enum marker. 1.. This has double
+dots. v1.0 Version numbers can break.
+
+// === EDGE CASES ===
+-1. 00. 01. Text about version 18446744073709551615. should stay glued.
+Reference to item 18446744073709551616. should break (overflow).
+
+// Punctuation after potential markers
+Sentence about version 1. (with parentheses). Text mentioning chapter 2. "with
+quotes". Discussion of point 3. *with emphasis*. Reference to section 4.
+`with code`. Price is \$5. New sentence starts here.
+
+// === enum markers ===
+01. Item with leading zero.
+007. Another item with leading zeros.
+18446744073709551615. That's OK
+18446744073709551616. This will overflow


### PR DESCRIPTION
fixes #403 