### PR TITLE
feat(web): show output and status of selected range in playground

### DIFF
--- a/playground/src/components/editor/SourceEditor.tsx
+++ b/playground/src/components/editor/SourceEditor.tsx
@@ -1,5 +1,5 @@
 import diff from "fast-diff";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as typstyle from "typstyle-wasm";
 import type { editor, Monaco } from "@/monaco/types";
 import { type FormatOptions, formatOptionsToConfig } from "@/utils/formatter";
@@ -19,11 +19,17 @@ export function SourceEditor({
   formatOptions,
 }: SourceEditorProps) {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+  const [wordWrap, setWordWrap] = useState(false);
+
   // Keep latest options in a ref to ensure formatting functions always use current values
   const formatOptionsRef = useRef(formatOptions);
   useEffect(() => {
     formatOptionsRef.current = formatOptions;
   }, [formatOptions]);
+
+  const toggleWordWrap = () => {
+    setWordWrap((prev) => !prev);
+  };
 
   const handleEditorMount = (
     editor: editor.IStandaloneCodeEditor,
@@ -42,6 +48,13 @@ export function SourceEditor({
       monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KeyF,
       formatSelection,
       "Format Selection",
+    );
+
+    // Add word wrap toggle command
+    editor.addCommand(
+      monaco.KeyMod.Alt | monaco.KeyCode.KeyZ,
+      toggleWordWrap,
+      "Toggle Word Wrap",
     );
 
     // Add context menu actions
@@ -65,6 +78,16 @@ export function SourceEditor({
       contextMenuGroupId: "1_modification",
       contextMenuOrder: 1.6,
       run: formatSelection,
+    });
+
+    // Add word wrap toggle action
+    editor.addAction({
+      id: "toggle-word-wrap",
+      label: "Toggle Word Wrap",
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
+      contextMenuGroupId: "9_view",
+      contextMenuOrder: 1.5,
+      run: toggleWordWrap,
     });
   };
 
@@ -165,7 +188,7 @@ export function SourceEditor({
       indentSize={0}
       readOnly={false}
       options={{
-        wordWrap: "on",
+        wordWrap: wordWrap ? "on" : "off",
         minimap: { enabled: true },
         rulers: lineLengthGuide ? [lineLengthGuide] : [],
       }}

--- a/playground/src/components/forms/RangeControls.tsx
+++ b/playground/src/components/forms/RangeControls.tsx
@@ -1,0 +1,33 @@
+import { useId } from "react";
+
+interface RangeControlsProps {
+  isRangeMode: boolean;
+  onRangeModeChange: (enabled: boolean) => void;
+}
+
+export function RangeControls({
+  isRangeMode,
+  onRangeModeChange,
+}: RangeControlsProps) {
+  const rangeModeId = useId();
+
+  return (
+    <div className="p-2 border-t border-base-300 text-sm">
+      <div className="flex items-center justify-between w-full">
+        <label htmlFor={rangeModeId} className="flex flex-col">
+          <span className="font-medium">Range Only Mode</span>
+          <small className="text-xs opacity-70">
+            Format/AST/IR only selected text
+          </small>
+        </label>
+        <input
+          id={rangeModeId}
+          type="checkbox"
+          className="checkbox"
+          checked={isRangeMode}
+          onChange={(e) => onRangeModeChange(e.target.checked)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/playground/src/components/ui/StatusBar.tsx
+++ b/playground/src/components/ui/StatusBar.tsx
@@ -1,0 +1,38 @@
+import type { DetailedEditorSelection } from "@/utils/editor-selection";
+
+interface StatusBarProps {
+  detailedSelection: DetailedEditorSelection | null;
+}
+
+export function StatusBar({ detailedSelection }: StatusBarProps) {
+  if (!detailedSelection) {
+    return (
+      <div className="flex items-center justify-between px-2 py-0.5 text-[10px] bg-base-200 border-t border-base-300">
+        <div className="opacity-60">Ready</div>
+      </div>
+    );
+  }
+
+  const position = `Ln ${detailedSelection.startLine}, Col ${detailedSelection.startColumn}`;
+
+  const selectionInfo = detailedSelection.isEmpty
+    ? ""
+    : detailedSelection.lineCount > 1
+      ? ` (${detailedSelection.lineCount} lines, ${detailedSelection.characterCount} chars selected)`
+      : ` (${detailedSelection.characterCount} chars selected)`;
+
+  return (
+    <div className="flex items-center justify-between px-2 py-0.5 text-[10px] bg-base-200 border-t border-base-300">
+      <div className="opacity-60">
+        {position}
+        {selectionInfo}
+      </div>
+      {!detailedSelection.isEmpty && (
+        <div className="opacity-60">
+          Range: {detailedSelection.startLine}:{detailedSelection.startColumn}-
+          {detailedSelection.endLine}:{detailedSelection.endColumn}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/playground/src/components/ui/index.ts
+++ b/playground/src/components/ui/index.ts
@@ -1,3 +1,4 @@
 export { LoadingSpinner } from "./LoadingSpinner";
+export { StatusBar } from "./StatusBar";
 export type { TabItem, TabProps, TabsProps } from "./Tabs";
 export { Tab, Tabs } from "./Tabs";

--- a/playground/src/hooks/index.ts
+++ b/playground/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useEditorSelection } from "./use-editor-selection";
 export { usePlaygroundState } from "./use-playground-state";
 export { useScreenSize } from "./use-screen-size";
 export { useTheme } from "./use-theme";

--- a/playground/src/hooks/use-editor-selection.ts
+++ b/playground/src/hooks/use-editor-selection.ts
@@ -1,0 +1,32 @@
+import { useCallback, useState } from "react";
+import type {
+  DetailedEditorSelection,
+  EditorSelection,
+} from "@/utils/editor-selection";
+
+export function useEditorSelection() {
+  const [detailedSelection, setDetailedSelection] =
+    useState<DetailedEditorSelection | null>(null);
+
+  // Derive basic selection directly - no need for memoization since it changes frequently
+  const selection: EditorSelection = detailedSelection
+    ? {
+        startOffset: detailedSelection.startOffset,
+        endOffset: detailedSelection.endOffset,
+        isEmpty: detailedSelection.isEmpty,
+      }
+    : { startOffset: 0, endOffset: 0, isEmpty: true };
+
+  const updateSelection = useCallback(
+    (newSelection: DetailedEditorSelection) => {
+      setDetailedSelection(newSelection);
+    },
+    [],
+  );
+
+  return {
+    selection,
+    detailedSelection,
+    updateSelection,
+  };
+}

--- a/playground/src/types.ts
+++ b/playground/src/types.ts
@@ -1,7 +1,14 @@
 // Types for the Typstyle Playground application
 
+import type { EditorSelection } from "./utils/editor-selection";
+
 export type ThemeType = "light" | "dark";
 
 export type ScreenSizeType = "wide" | "thin";
 
 export type OutputType = "formatted" | "ast" | "ir";
+
+export interface RangeFormatterOptions {
+  selection: EditorSelection;
+  fullText: string;
+}

--- a/playground/src/utils/editor-selection.ts
+++ b/playground/src/utils/editor-selection.ts
@@ -1,0 +1,56 @@
+import type { editor, monaco } from "@/monaco/types";
+
+/**
+ * Selection types for range-based operations
+ */
+export interface EditorSelection {
+  startOffset: number;
+  endOffset: number;
+  isEmpty: boolean;
+}
+
+/**
+ * Enhanced editor selection with line/column information
+ */
+export interface DetailedEditorSelection extends EditorSelection {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+  lineCount: number;
+  characterCount: number;
+}
+
+/**
+ * Convert Monaco selection to character offsets and detailed information
+ * @param selection Monaco selection object
+ * @param model Monaco text model for offset calculations
+ */
+export function convertSelectionToOffsets(
+  selection: monaco.Selection,
+  model: editor.ITextModel,
+): DetailedEditorSelection {
+  const startOffset = model.getOffsetAt({
+    lineNumber: selection.startLineNumber,
+    column: selection.startColumn,
+  });
+  const endOffset = model.getOffsetAt({
+    lineNumber: selection.endLineNumber,
+    column: selection.endColumn,
+  });
+
+  const lineCount = selection.endLineNumber - selection.startLineNumber + 1;
+  const characterCount = endOffset - startOffset;
+
+  return {
+    startOffset,
+    endOffset,
+    isEmpty: selection.isEmpty(),
+    startLine: selection.startLineNumber,
+    startColumn: selection.startColumn,
+    endLine: selection.endLineNumber,
+    endColumn: selection.endColumn,
+    lineCount,
+    characterCount,
+  };
+}


### PR DESCRIPTION
also added toggle word wrap in the editor

<img width="1910" height="933" alt="image" src="https://github.com/user-attachments/assets/9a7c8eb4-55c2-45df-8da1-0ef2872b6ef0" />
