### PR TITLE
feat: change indentation size of AST/IR from 4 to 2

### DIFF
--- a/crates/typstyle-core/src/lib.rs
+++ b/crates/typstyle-core/src/lib.rs
@@ -11,7 +11,9 @@ pub use attr::AttrStore;
 pub use config::Config;
 use pretty::{prelude::*, PrettyPrinter};
 use thiserror::Error;
-use typst_syntax::Source;
+use typst_syntax::{Source, SyntaxNode};
+
+use crate::utils::indent_4_to_2;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -61,7 +63,7 @@ impl<'a> Formatter<'a> {
     /// Renders the document's pretty IR.
     pub fn render_ir(&'a self) -> Result<String, Error> {
         let doc = self.build_doc()?;
-        Ok(format!("{doc:#?}"))
+        Ok(indent_4_to_2(&format!("{doc:#?}")))
     }
 
     /// Renders the formatted document to a string.
@@ -83,4 +85,9 @@ impl<'a> Formatter<'a> {
         let doc = self.printer.convert_markup(Default::default(), markup);
         Ok(doc)
     }
+}
+
+/// Formats a `SyntaxNode` as a debug AST string with 2-space indentation.
+pub fn format_ast(root: &SyntaxNode) -> String {
+    indent_4_to_2(&format!("{root:#?}"))
 }

--- a/crates/typstyle-core/src/utils.rs
+++ b/crates/typstyle-core/src/utils.rs
@@ -1,5 +1,3 @@
-use std::ops::Range;
-
 /// Strip trailing whitespace in each line of the input string.
 pub fn strip_trailing_whitespace(s: &str) -> String {
     if s.is_empty() {
@@ -11,13 +9,6 @@ pub fn strip_trailing_whitespace(s: &str) -> String {
         res.push('\n');
     }
     res
-}
-
-/// Get the range of the string obtained from trimming in the original string.
-pub fn trim_range(s: &str, mut rng: Range<usize>) -> Range<usize> {
-    rng.end = rng.start + s[rng.clone()].trim_end().len();
-    rng.start = rng.end - s[rng.clone()].trim_start().len();
-    rng
 }
 
 pub fn count_spaces_after_last_newline(s: &str, i: usize) -> usize {
@@ -39,6 +30,64 @@ pub fn count_spaces_after_last_newline(s: &str, i: usize) -> usize {
     }
 }
 
+/// Changes the indentation of a formatted string from one size to another.
+///
+/// This function converts space-only indentation from one size to another while
+/// preserving the relative indentation structure. Assumes input uses only spaces
+/// and indentation is always a multiple of the given indent size.
+///
+/// # Arguments
+/// - `text`: The input text with existing space indentation
+/// - `from_indent`: The current indentation size (e.g., 4 for 4 spaces)
+/// - `to_indent`: The desired indentation size (e.g., 2 for 2 spaces)
+///
+/// # Examples
+/// ```
+/// use typstyle_core::utils::change_indent;
+///
+/// let input = "    line1\n        line2\n    line3";
+/// let output = change_indent(input, 4, 2);
+/// assert_eq!(output, "  line1\n    line2\n  line3");
+/// ```
+pub fn change_indent(text: &str, from_indent: usize, to_indent: usize) -> String {
+    if text.is_empty() || from_indent == 0 || from_indent == to_indent {
+        return text.to_string();
+    }
+
+    let mut result = String::with_capacity(text.len());
+    let mut first = true;
+
+    for line in text.lines() {
+        if !first {
+            result.push('\n');
+        }
+        first = false;
+
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() {
+            // Keep blank lines empty
+            continue;
+        } else {
+            let leading_spaces = line.len() - trimmed.len();
+            let indent_level = leading_spaces / from_indent;
+            let new_indent_size = to_indent * indent_level;
+
+            // Build new line with correct indentation
+            for _ in 0..new_indent_size {
+                result.push(' ');
+            }
+            result.push_str(trimmed);
+        }
+    }
+
+    result
+}
+
+/// Convenience function to change space indentation from 4 to 2 spaces
+pub fn indent_4_to_2(text: &str) -> String {
+    change_indent(text, 4, 2)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -55,5 +104,18 @@ mod tests {
         assert_eq!(s, "\n -\n");
         let s = strip_trailing_whitespace(" \n - \n ");
         assert_eq!(s, "\n -\n\n");
+    }
+
+    #[test]
+    fn test_change_indent_basic() {
+        let input = "    line1\n        line2\n    line3";
+        let output = change_indent(input, 4, 2);
+        assert_eq!(output, "  line1\n    line2\n  line3");
+    }
+
+    #[test]
+    fn test_change_indent_empty() {
+        assert_eq!(change_indent("", 4, 2), "");
+        assert_eq!(change_indent("   ", 4, 2), "");
     }
 }

--- a/crates/typstyle-typlugin/Cargo.toml
+++ b/crates/typstyle-typlugin/Cargo.toml
@@ -13,6 +13,7 @@ homepage.workspace = true
 [lib]
 crate-type = ["cdylib"]
 bench = false
+test = false
 
 [dependencies]
 typstyle-core = { workspace = true, features = ["serde"] }

--- a/crates/typstyle-typlugin/src/lib.rs
+++ b/crates/typstyle-typlugin/src/lib.rs
@@ -1,4 +1,4 @@
-use typstyle_core::{Config, Typstyle};
+use typstyle_core::{format_ast, Config, Typstyle};
 use wasm_minimal_protocol::*;
 
 initiate_protocol!();
@@ -12,7 +12,7 @@ pub fn parse(text: &[u8]) -> WasmResult {
     let text = parse_text(text)?;
 
     let root = typst_syntax::parse(text);
-    let ret = format!("{root:#?}");
+    let ret = format_ast(&root);
 
     Ok(ret.into_bytes())
 }

--- a/crates/typstyle-wasm/Cargo.toml
+++ b/crates/typstyle-wasm/Cargo.toml
@@ -13,6 +13,7 @@ homepage.workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 bench = false
+test = false
 
 [features]
 default = ["console_error_panic_hook"]

--- a/crates/typstyle-wasm/src/lib.rs
+++ b/crates/typstyle-wasm/src/lib.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use js_sys::Error;
 use typst_syntax::Source;
-use typstyle_core::{partial::get_node_for_range, Config, Typstyle};
+use typstyle_core::{format_ast, partial::format_range_ast, Config, Typstyle};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -25,7 +25,7 @@ pub fn run() {
 #[wasm_bindgen]
 pub fn parse(text: &str) -> Result<String, Error> {
     let root = typst_syntax::parse(text);
-    Ok(format!("{root:#?}"))
+    Ok(format_ast(&root))
 }
 
 /// Formats the content using the provided configuration.
@@ -79,9 +79,9 @@ pub fn format_range(
     let config = parse_config(config)?;
     let t = Typstyle::new(config);
     let source = Source::detached(text);
-    let uft8_range = to_utf16_range(&source, start, end)?;
+    let utf8_range = to_utf16_range(&source, start, end)?;
 
-    match t.format_source_range(source.clone(), uft8_range) {
+    match t.format_source_range(source.clone(), utf8_range) {
         Ok(result) => Ok(FormatRangeResult {
             start: source
                 .byte_to_utf16(result.source_range.start)
@@ -107,9 +107,9 @@ pub fn format_range_ir(
     let config = parse_config(config)?;
     let t = Typstyle::new(config);
     let source = Source::detached(text);
-    let uft8_range = to_utf16_range(&source, start, end)?;
+    let utf8_range = to_utf16_range(&source, start, end)?;
 
-    match t.format_source_range_ir(source, uft8_range) {
+    match t.format_source_range_ir(source, utf8_range) {
         Ok(result) => Ok(result.content),
         Err(e) => Err(into_error(e)),
     }
@@ -120,10 +120,10 @@ pub fn format_range_ir(
 #[wasm_bindgen]
 pub fn get_range_ast(text: &str, start: usize, end: usize) -> Result<String, Error> {
     let source = Source::detached(text);
-    let uft8_range = to_utf16_range(&source, start, end)?;
+    let utf8_range = to_utf16_range(&source, start, end)?;
 
-    match get_node_for_range(&source, uft8_range) {
-        Ok(node) => Ok(format!("{node:#?}")),
+    match format_range_ast(&source, utf8_range) {
+        Ok(result) => Ok(result.content),
         Err(e) => Err(into_error(e)),
     }
 }

--- a/crates/typstyle/src/fmt.rs
+++ b/crates/typstyle/src/fmt.rs
@@ -12,7 +12,7 @@ use anyhow::{bail, Context, Result};
 use itertools::Itertools;
 use log::{debug, error, info, warn};
 use typst_syntax::Source;
-use typstyle_core::{Config, Typstyle};
+use typstyle_core::{format_ast, Config, Typstyle};
 use walkdir::{DirEntry, WalkDir};
 
 use crate::{
@@ -212,7 +212,7 @@ fn format_debug(content: &str, typstyle: &Typstyle, args: &DebugArgs) -> FormatR
     let source = Source::detached(content);
     let root = source.root();
     if args.ast {
-        println!("{root:#?}");
+        println!("{}", format_ast(root));
     }
 
     let start_time = Instant::now();

--- a/crates/typstyle/tests/test_format_stdin.rs
+++ b/crates/typstyle/tests/test_format_stdin.rs
@@ -139,24 +139,24 @@ fn test_stdin_debug_ast() {
     exit_code: 0
     ----- stdout -----
     Markup: 16 [
-        Hash: "#",
-        LetBinding: 15 [
-            Let: "let",
-            Space: "  ",
-            Ident: "x",
-            Space: "  ",
-            Eq: "=",
-            Space: " ",
-            Parenthesized: 5 [
-                LeftParen: "(",
-                Binary: 3 [
-                    Int: "1",
-                    Plus: "+",
-                    Int: "2",
-                ],
-                RightParen: ")",
-            ],
+      Hash: "#",
+      LetBinding: 15 [
+        Let: "let",
+        Space: "  ",
+        Ident: "x",
+        Space: "  ",
+        Eq: "=",
+        Space: " ",
+        Parenthesized: 5 [
+          LeftParen: "(",
+          Binary: 3 [
+            Int: "1",
+            Plus: "+",
+            Int: "2",
+          ],
+          RightParen: ")",
         ],
+      ],
     ]
     #let x = (1 + 2)
 


### PR DESCRIPTION
make output not too wide

we may need a function to print ast, avoiding duplication of changing indents in wasm bindings